### PR TITLE
Remove `/style-guide` Route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -28,4 +28,3 @@ Auth::routes();
 Route::get('/', 'HomeController@index')->name('home');
 
 Route::get('/styles', 'StyleController@index')->name('styles.index');
-Route::get('/style-guide', 'StyleController@styleGuide')->name('styles.styleGuide');


### PR DESCRIPTION
Fixes #190

# Summary
Removes the `/style-guide` route since it is not in use.