### PR TITLE
Event API `starts_at` + `ends_at` filter should use start of day and end of day

### DIFF
--- a/app-modules/api/src/Http/Controllers/EventApiV0Controller.php
+++ b/app-modules/api/src/Http/Controllers/EventApiV0Controller.php
@@ -14,10 +14,10 @@ class EventApiV0Controller
         return new EventCollection(
             resource: Event::query()
                 ->when($request->filled('start_date'), function (Builder $query) use ($request) {
-                    $query->where('active_at', '>=', $request->date('start_date'));
+                    $query->where('active_at', '>=', $request->date('start_date')->startOfDay());
                 })
                 ->when($request->filled('end_date'), function (Builder $query) use ($request) {
-                    $query->where('active_at', '<=', $request->date('end_date'));
+                    $query->where('active_at', '<=', $request->date('end_date')->endOfDay());
                 })
                 ->when($request->filled('tags'), function (Builder $query) use ($request) {
                     $query->whereHas('organization.tags', function (Builder $query) use ($request) {


### PR DESCRIPTION
Matt mentioned this being an issue via slack, this should address the concern.


> https://stage.hackgreenville.com/api/v0/events?start_date=2023-12-03&end_date=2023-12-09 doesn't show the items for 12-09-2023, so the end date isn't inclusive (end_date=2023-12-09 is up to and including Dec 9th, 2023 00:00:00 which misses out on the rest of the day). It might be something we'd want to tweak, but since a consumer can just bump the day up one in their query I'm considering this a super low severity item.