### PR TITLE
Set `import:events` Command to Run Hourly

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,7 +16,7 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command(ImportEventsCommand::class)->everyThreeHours();
+        $schedule->command(ImportEventsCommand::class)->hourly();
     }
 
     /**


### PR DESCRIPTION
Resolves #197

# Description
Adjusts the configuration for the `import:events` command so that it runs hourly opposed to every three hours.