### PR TITLE
Document the Events API and Variables

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -75,7 +75,8 @@
       "contributions": [
         "code",
         "bug",
-        "ideas"
+        "ideas",
+        "docs"
       ]
     },
     {
@@ -182,15 +183,6 @@
       "profile": "https://github.com/Alex-Grimes",
       "contributions": [
         "code"
-      ]
-    },
-    {
-      "login": "JSn1nj4",
-      "name": "JSn1nj4",
-      "avatar_url": "https://avatars.githubusercontent.com/u/5084820?v=4",
-      "profile": "https://github.com/JSn1nj4",
-      "contributions": [
-        "doc"
       ]
     }
   ],

--- a/.env.docker
+++ b/.env.docker
@@ -66,12 +66,12 @@ EVENTBRITE_PRIVATE_TOKEN=
 
 # The maximum number of days in the past that the "Import" function
 # will request from the remote event services
-# This can indirection limit the consuming application's end_date
+# This can indirectly limit the consuming application's end_date
 EVENT_IMPORTER_MAX_DAYS_IN_PAST=30
 
 # The maximum number of days in the future that the "Import" function
 # will request from the remote event services
-# This can indirection limit the consuming application's end_date
+# This can indirectly limit the consuming application's end_date
 EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=180
 
 # When no start_date is provided by the consuming application, this many days

--- a/.env.docker
+++ b/.env.docker
@@ -60,3 +60,21 @@ GOOGLE_TAG_MANAGER=
 HCAPTCHA_SITEKEY=
 HCAPTCHA_SECRET=
 SLACK_CONTACT_WEBHOOK=
+
+# The private Eventbrite API key / token for importing events
+EVENTBRITE_PRIVATE_TOKEN=
+
+# The maximum number of days in the past that the "Import" function
+# will request from the remote event services
+# This can indirection limit the consuming application's end_date
+EVENT_IMPORTER_MAX_DAYS_IN_PAST=30
+
+# The maximum number of days in the future that the "Import" function
+# will request from the remote event services
+# This can indirection limit the consuming application's end_date
+EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=180
+
+# When no start_date is provided by the consuming application, this many days
+# in the past will be returned.  That is, start_date = {today's date - EVENTS_API_DEFAULT_DAYS}
+EVENTS_API_DEFAULT_DAYS=1
+

--- a/.env.docker
+++ b/.env.docker
@@ -66,7 +66,7 @@ EVENTBRITE_PRIVATE_TOKEN=
 
 # The maximum number of days in the past that the "Import" function
 # will request from the remote event services
-# This can indirectly limit the consuming application's end_date
+# This can indirectly limit the consuming application's start_date
 EVENT_IMPORTER_MAX_DAYS_IN_PAST=30
 
 # The maximum number of days in the future that the "Import" function

--- a/.env.example
+++ b/.env.example
@@ -51,9 +51,19 @@ HCAPTCHA_SITEKEY=
 HCAPTCHA_SECRET=
 SLACK_CONTACT_WEBHOOK=
 
+# The private Eventbrite API key / token for importing events
 EVENTBRITE_PRIVATE_TOKEN=
 
+# The maximum number of days in the past that the "Import" function
+# will request from the remote event services
+# This can indirection limit the consuming application's end_date
 EVENT_IMPORTER_MAX_DAYS_IN_PAST=30
+
+# The maximum number of days in the future that the "Import" function
+# will request from the remote event services
+# This can indirection limit the consuming application's end_date
 EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=180
 
+# When no start_date is provided by the consuming application, this many days
+# in the past will be returned.  That is, start_date = {today's date - EVENTS_API_DEFAULT_DAYS}
 EVENTS_API_DEFAULT_DAYS=1

--- a/.env.example
+++ b/.env.example
@@ -56,12 +56,12 @@ EVENTBRITE_PRIVATE_TOKEN=
 
 # The maximum number of days in the past that the "Import" function
 # will request from the remote event services
-# This can indirection limit the consuming application's end_date
+# This can indirectly limit the consuming application's end_date
 EVENT_IMPORTER_MAX_DAYS_IN_PAST=30
 
 # The maximum number of days in the future that the "Import" function
 # will request from the remote event services
-# This can indirection limit the consuming application's end_date
+# This can indirectly limit the consuming application's end_date
 EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=180
 
 # When no start_date is provided by the consuming application, this many days

--- a/.env.example
+++ b/.env.example
@@ -56,7 +56,7 @@ EVENTBRITE_PRIVATE_TOKEN=
 
 # The maximum number of days in the past that the "Import" function
 # will request from the remote event services
-# This can indirectly limit the consuming application's end_date
+# This can indirectly limit the consuming application's start_date
 EVENT_IMPORTER_MAX_DAYS_IN_PAST=30
 
 # The maximum number of days in the future that the "Import" function

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -300,8 +300,8 @@ The Events API's responses are controlled by variables that may limit the data a
 Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the [HackGreenville.com Events API](/EVENTS_API.md)
 
 Explaination of the .env defaults
-`EVENT_IMPORTER_MAX_DAYS_IN_PAST=30` would limit the responses to no more than 30 days in the past
-`EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=365` would .env will limit the responses to no more than 365 days in the future
+`EVENT_IMPORTER_MAX_DAYS_IN_PAST=30` would limit the imported events saved in the Event API's to no more than 30 days in the past
+`EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=365` would .env will limit the imported events saved in the Event API's database to no more than 365 days in the future
 `EVENTS_API_DEFAULT_DAYS=1` would cause responses to include at least 1 day in the past. This variable is intended to help avoid ongoing events from disappearing from the API response until at least 24 hours after it started.
  
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -291,7 +291,7 @@ docker exec "hackgreenville" /bin/bash -c "php artisan import:events"
 
 # Environment Variables
 
-- The sample .env.example OR .env.docker is used as a template for new projects and one must exist based on how the app is running (Native or Docker)
+- The sample .env.example OR .env.docker is used as a template for new projects. A .env file must exist based on one of these files, based on how the app is running (Native or Docker)
 - The .env.ci and .env.testing are used for their respective tasks.
 
 ## Events API Configuration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -297,7 +297,7 @@ docker exec "hackgreenville" /bin/bash -c "php artisan import:events"
 ## Events API Configuration
 The Events API's responses are controlled by variables that may limit the data available to calling / consuming applications.
 
-Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the [HackGreenville.com Events API](https://github.com/hackgvl/hackgreenville.com/EVENTS_API.md)
+Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the [HackGreenville.com Events API](/EVENTS_API.md)
 
 Explaination of the .env defaults
 `EVENT_IMPORTER_MAX_DAYS_IN_PAST=30` would limit the responses to no more than 30 days in the past

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,7 @@
 - [Forking the Project](#forking-the-project)
 - [Running the App](#running-the-app)
 - [Interacting with Your Running App](#interacting-with-your-running-app)
+- [Environment Variables](#environment-variables)
 - [Synchronizing Your Fork with the Latest Development Code Changes](#synchronizing-your-fork-with-the-latest-development-code-changes)
 - [Contributing Code to the Project](#contributing-code-to-the-project)
 - [Frequently Asked Questions](#frequently-asked-questions)
@@ -286,6 +287,23 @@ docker exec "hackgreenville" /bin/bash -c "php artisan import:events"
 - Refreshing events from the remote API: `php artisan import:events`
 - Run database migrations: `php artisan migrate --seed`
 - Completely erase and rebuild the database: [Danger Zone] `php artisan migrate:fresh --seed` [/Danger Zone]
+
+
+# Environment Variables
+
+- The sample .env.example OR .env.docker is used as a template for new projects and one must exist based on how the app is running (Native or Docker)
+- The .env.ci and .env.testing are used for their respective tasks.
+
+## Events API Configuration
+The Events API's responses are controlled by variables that may limit the data available to calling / consuming applications.
+
+Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the [HackGreenville.com Events API](https://github.com/hackgvl/hackgreenville.com/EVENTS_API.md)
+
+Explaination of the .env defaults
+`EVENT_IMPORTER_MAX_DAYS_IN_PAST=30` would limit the responses to no more than 30 days in the past
+`EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=365` would .env will limit the responses to no more than 365 days in the future
+`EVENTS_API_DEFAULT_DAYS=1` would cause responses to include at least 1 day in the past. This variable is intended to help avoid ongoing events from disappearing from the API response until at least 24 hours after it started.
+ 
 
 
 # Synchronizing Your Fork with the Latest Development Code Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,10 +36,11 @@ If you can't find what you were looking for then [open a new issue](https://gith
 
 When in doubt, you can reach out to an active project contributor:
 
-| Name          | GitHub                                   | Role                               |
-|:--------------|:-----------------------------------------|:-----------------------------------|
-| Zach          | [@zach2825](https://github.com/zach2825) | Technical Lead, Laravel            |
-| Jim Ciallella | [@allella](https://github.com/allella)   | Bugs, Documentation, Newcomer Help |
+| Name          | GitHub                                                   | Role                               |
+|:--------------|:---------------------------------------------------------|:-----------------------------------|
+| Bogdan        | [@bogdankharchenko](https://github.com/bogdankharchenko) | Technical Lead, Laravel            |
+| Zach          | [@zach2825](https://github.com/zach2825)                 | Technical Lead, Laravel            |
+| Jim Ciallella | [@allella](https://github.com/allella)                   | Bugs, Documentation, Newcomer Help |
 
 
 # Forking the Project
@@ -181,7 +182,7 @@ php artisan key:generate
 
 ### Import / Seed the Organizations and Events Data
 
-Organization and events data comes from the [Organizations API](https://github.com/hackgvl/OpenData/blob/master/ORGANIZATIONS_API.md) and [Events API](https://github.com/hackgvl/events-api). Without this step the application will have no data.
+Organization and events data comes from the [Organizations API](https://github.com/hackgvl/OpenData/blob/master/ORGANIZATIONS_API.md) and [Events API](/EVENTS_API.md). Without this step the application will have no data.
 
 
 ```bash
@@ -300,7 +301,7 @@ The Events API's responses are controlled by variables that may limit the data a
 Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the [HackGreenville.com Events API](/EVENTS_API.md)
 
 Explaination of the .env defaults
-`EVENT_IMPORTER_MAX_DAYS_IN_PAST=30` would limit the imported events saved in the Event API's to no more than 30 days in the past
+`EVENT_IMPORTER_MAX_DAYS_IN_PAST=30` would limit the imported events saved in the Event API's database to no more than 30 days in the past
 `EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=365` would .env will limit the imported events saved in the Event API's database to no more than 365 days in the future
 `EVENTS_API_DEFAULT_DAYS=1` would cause responses to include at least 1 day in the past. This variable is intended to help avoid ongoing events from disappearing from the API response until at least 24 hours after it started.
  

--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -1,14 +1,24 @@
 # Interacting with the Events API
 
-By default, results are returned in JSON format.  If an `Accept: application/json+ld` header is sent to the API, then it will reply with [Schema.org Event markup](https://schema.org/Event) in JSON+LD format.
+## URLs and Query String Parameters
+By default, results are returned in JSON format.
+
+Previously, an `Accept: application/json+ld` header could be sent to the API to fetch [Schema.org Event markup](https://schema.org/Event) in JSON+LD format. However, this feature is not implemented in the newest version.
 
 * [Get all upcoming events](https://hackgreenville.com/api/v0/events) by calling _/api/v0/events_
 * [Get events within a date range](https://hackgreenville.com/api/v0/events?start_date=2024-01-15&end_date=2024-02-01) by calling _/api/v0/events?start_date=2024-01-15&end_date=2024-02-01_
     * the API defaults to providing only upcoming meetings, unless a `start_date` and `end_date` are specified
-    * "past events" are limited by the `[past_events] max_days_in_the_past` set in the config.ini file
+    * the API may only reply with a limited number of days in the past, as defined in the API's server configuration
     * "US/Eastern" is assumed as the timezone when a date filter is provided
 * [Get events with a specific organizations tag](https://hackgreenville.com/api/v0/events?tags=1) by calling _/api/v0/events?tags=1_ - "tags" are applied to an organization in the [organizations API](https://github.com/hackgvl/OpenData/issues/17).  Currently, the organizations API only provides integer tag IDs, such as with this tag #1, representing OpenWorks hosted events, The format of the JSON that returns is:
 * The query parameters can be combined, so you could [request only events for a specific tag, during a specific date range](https://hackgreenville.com/api/v0/events?tags=1&start_date=2024-01-15&end_date=2024-02-01), like _/api/v0/events?tags=1&start_date=2024-01-15&end_date=2024-02-01_
+
+## Limitations and Gotchas
+* The Events API's responses are controlled by variables that may limit the data available to calling / consuming applications. Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the HackGreenville.com Events API endpoints referenced above.
+* All timestamps are in UTC.  
+* The event description fields may include HTML markup.  This application does not sanitize those fields and it's unclear if the upstream source should be trusted, so sanitize any output to avoid malicious cross-site scripting (XSS).
+
+## Sample JSON Event Object Response
 
 ```
 {
@@ -39,8 +49,6 @@ By default, results are returned in JSON format.  If an `Accept: application/jso
 }
 ```
 
-Note:
-* All timestamps are in UTC.  
-* The event description fields may include HTML markup.  This application does not sanitize those fields and it's unclear if the upstream source should be trusted, so sanitize any output to avoid malicious XSS.
-* Kudos to @Nunie123 for the initial development and @ramona-spence for sustaining the [earlier Python repository](https://github.com/hackgvl/events-api).
+## Kudos to Past Contributors
+Thanks to @Nunie123 for the initial development, and to @ramona-spence for sustaining the [previous Python implementation](https://github.com/hackgvl/events-api).
 

--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -1,0 +1,46 @@
+# Interacting with the Events API
+
+By default, results are returned in JSON format.  If an `Accept: application/json+ld` header is sent to the API, then it will reply with [Schema.org Event markup](https://schema.org/Event) in JSON+LD format.
+
+* [Get all upcoming events](https://hackgreenville.com/api/v0/events) by calling _/api/v0/events_
+* [Get events within a date range](https://hackgreenville.com/api/v0/events?start_date=2024-01-15&end_date=2024-02-01) by calling _/api/v0/events?start_date=2024-01-15&end_date=2024-02-01_
+    * the API defaults to providing only upcoming meetings, unless a `start_date` and `end_date` are specified
+    * "past events" are limited by the `[past_events] max_days_in_the_past` set in the config.ini file
+    * "US/Eastern" is assumed as the timezone when a date filter is provided
+* [Get events with a specific organizations tag](https://hackgreenville.com/api/v0/events?tags=1) by calling _/api/v0/events?tags=1_ - "tags" are applied to an organization in the [organizations API](https://github.com/hackgvl/OpenData/issues/17).  Currently, the organizations API only provides integer tag IDs, such as with this tag #1, representing OpenWorks hosted events, The format of the JSON that returns is:
+* The query parameters can be combined, so you could [request only events for a specific tag, during a specific date range](https://hackgreenville.com/api/v0/events?tags=1&start_date=2024-01-15&end_date=2024-02-01), like _/api/v0/events?tags=1&start_date=2024-01-15&end_date=2024-02-01_
+
+```
+{
+	"event_name":"Calm Rails Upgrades",
+	"group_name":"Upstate Ruby",
+	"group_url":"https:\/\/twitter.com\/upstateruby",
+	"url":"https:\/\/www.meetup.com\/upstate-ruby\/events\/298465949\/",
+	"time":"2024-01-25T23:30:00.000000Z",
+	"tags":1,
+	"status":"upcoming",
+	"rsvp_count":7,
+	"description":"<p>Upgrading a Rails app can be daunting and stressful. Make your next Rails upgrade calm and oddly satisfying.<\/p> ",
+	"uuid":"5fe306da6dc0df14fb6c182229d3ebe6",
+	"data_as_of":"2024-01-23T18:49:52.738311Z",
+	"service_id":"298465949",
+	"service":"meetup",
+	"venue":{
+		"name":"OpenWorks",
+		"address":"101 N Main St #302",
+		"city":"Greenville",
+		"state":"SC",
+		"zip":"29601",
+		"country":"us",
+		"lat":"34.852020263672",
+		"lon":"-82.399681091309"
+	},
+	"created_at":"2024-01-11T21:37:20.000000Z"
+}
+```
+
+Note:
+* All timestamps are in UTC.  
+* The event description fields may include HTML markup.  This application does not sanitize those fields and it's unclear if the upstream source should be trusted, so sanitize any output to avoid malicious XSS.
+* Kudos to @Nunie123 for the initial development and @ramona-spence for sustaining the [earlier Python repository](https://github.com/hackgvl/events-api).
+

--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -8,7 +8,7 @@ By default, results are returned in JSON format.
     * the API defaults to providing only upcoming meetings, unless a `start_date` and `end_date` are specified
     * the API may only reply with a limited number of days in the past, as defined in the API's server configuration
     * "US/Eastern" is assumed as the timezone when a date filter is provided
-* [Get events with a specific organizations tag](https://hackgreenville.com/api/v0/events?tags=1) by calling _/api/v0/events?tags=1_ - "tags" are applied to an organization in the [organizations API](https://github.com/hackgvl/OpenData/issues/17).  Currently, the organizations API only provides integer tag IDs, such as with this tag #1, representing OpenWorks hosted events, The format of the JSON that returns is:
+* [Get events with a specific organizations tag](https://hackgreenville.com/api/v0/events?tags=1) by calling _/api/v0/events?tags=1_ - "tags" are applied to an organization in the [organizations API](https://github.com/codeforgreenville/OpenData/blob/master/ORGANIZATIONS_API.md).  Currently, the organizations API only provides integer tag IDs, such as with this tag #1, representing OpenWorks hosted events, The format of the JSON that returns is:
 * The query parameters can be combined, so you could [request only events for a specific tag, during a specific date range](https://hackgreenville.com/api/v0/events?tags=1&start_date=2024-01-15&end_date=2024-02-01), like _/api/v0/events?tags=1&start_date=2024-01-15&end_date=2024-02-01_
 
 ## Limitations and Gotchas

--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -49,5 +49,5 @@ By default, results are returned in JSON format.
 ```
 
 ## Kudos to Past Contributors
-Thanks to @Nunie123 for the initial development, and to @ramona-spence for sustaining the [previous Python implementation](https://github.com/hackgvl/events-api).
-
+* Thanks to @Nunie123 for the initial development, and to @ramona-spence for sustaining the [previous Python implementation](https://github.com/hackgvl/events-api).
+* Thanks to @bogdankharchenko for migrating the Python implementation to PHP / Laravel

--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -14,7 +14,7 @@ Previously, an `Accept: application/json+ld` header could be sent to the API to 
 * The query parameters can be combined, so you could [request only events for a specific tag, during a specific date range](https://hackgreenville.com/api/v0/events?tags=1&start_date=2024-01-15&end_date=2024-02-01), like _/api/v0/events?tags=1&start_date=2024-01-15&end_date=2024-02-01_
 
 ## Limitations and Gotchas
-* The Events API's responses are controlled by variables that may limit the data available to calling / consuming applications. Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the HackGreenville.com Events API endpoints referenced above.
+* The Events API's responses are controlled by [server .env variables](/CONTRIBUTING.md#environment-variables) that may limit the data available to calling / consuming applications. Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the HackGreenville.com Events API endpoints referenced above.
 * All timestamps are in UTC.  
 * The event description fields may include HTML markup.  This application does not sanitize those fields and it's unclear if the upstream source should be trusted, so sanitize any output to avoid malicious cross-site scripting (XSS).
 

--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -3,8 +3,6 @@
 ## URLs and Query String Parameters
 By default, results are returned in JSON format.
 
-Previously, an `Accept: application/json+ld` header could be sent to the API to fetch [Schema.org Event markup](https://schema.org/Event) in JSON+LD format. However, this feature is not implemented in the newest version.
-
 * [Get all upcoming events](https://hackgreenville.com/api/v0/events) by calling _/api/v0/events_
 * [Get events within a date range](https://hackgreenville.com/api/v0/events?start_date=2024-01-15&end_date=2024-02-01) by calling _/api/v0/events?start_date=2024-01-15&end_date=2024-02-01_
     * the API defaults to providing only upcoming meetings, unless a `start_date` and `end_date` are specified
@@ -17,6 +15,7 @@ Previously, an `Accept: application/json+ld` header could be sent to the API to 
 * The Events API's responses are controlled by [server .env variables](/CONTRIBUTING.md#environment-variables) that may limit the data available to calling / consuming applications. Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the HackGreenville.com Events API endpoints referenced above.
 * All timestamps are in UTC.  
 * The event description fields may include HTML markup.  This application does not sanitize those fields and it's unclear if the upstream source should be trusted, so sanitize any output to avoid malicious cross-site scripting (XSS).
+* Previously, an `Accept: application/json+ld` header could be sent to the API to fetch [Schema.org Event markup](https://schema.org/Event) in JSON+LD format. However, this feature is not implemented in the newest version.
 
 ## Sample JSON Event Object Response
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ See the [CONTRIBUTING.md](CONTRIBUTING.md) for the various options for running a
 # Tech Stack Notes
 
 ## APIs
-The organization data is queried from HackGreenville Labs's [Organizations API](https://github.com/hackgvl/OpenData/blob/master/ORGANIZATIONS_API.md).
+The organization data is queried from HackGreenville Labs' [Organizations API](https://github.com/hackgvl/OpenData/blob/master/ORGANIZATIONS_API.md).
 
-Then, for all of these organization, the events can be are queried from the [Events API](https://github.com/hackgvl/events-api).
+The events data is queried through the [Events API](https://github.com/hackgvl/hackgreenville.com/EVENTS_API.md), which is now part of this repository.
 
 ## Laravel
 This project uses the [Laravel PHP framework](https://laravel.com). The [CONTRIBUTING.md](CONTRIBUTING.md) goes into more technical details.
@@ -47,7 +47,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/magoun"><img src="https://avatars1.githubusercontent.com/u/6494252?v=4?s=100" width="100px;" alt="Creighton Magoun"/><br /><sub><b>Creighton Magoun</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=magoun" title="Code">💻</a> <a href="https://github.com/hackgvl/hackgreenville-com/issues?q=author%3Amagoun" title="Bug reports">🐛</a> <a href="#ideas-magoun" title="Ideas, Planning, & Feedback">🤔</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Jaaron0606"><img src="https://avatars1.githubusercontent.com/u/18074750?v=4?s=100" width="100px;" alt="James Aaron"/><br /><sub><b>James Aaron</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=Jaaron0606" title="Code">💻</a> <a href="https://github.com/hackgvl/hackgreenville-com/issues?q=author%3AJaaron0606" title="Bug reports">🐛</a> <a href="#ideas-Jaaron0606" title="Ideas, Planning, & Feedback">🤔</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/kevindees"><img src="https://avatars1.githubusercontent.com/u/348368?v=4?s=100" width="100px;" alt="Kevin Dees"/><br /><sub><b>Kevin Dees</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=kevindees" title="Code">💻</a> <a href="https://github.com/hackgvl/hackgreenville-com/issues?q=author%3Akevindees" title="Bug reports">🐛</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/JSn1nj4"><img src="https://avatars1.githubusercontent.com/u/5084820?v=4?s=100" width="100px;" alt="Elliot Derhay"/><br /><sub><b>Elliot Derhay</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=JSn1nj4 " title="Code">💻</a> <a href="https://github.com/hackgvl/hackgreenville-com/issues?q=author%3AJSn1nj4 " title="Bug reports">🐛</a> <a href="#ideas-JSn1nj4 " title="Ideas, Planning, & Feedback">🤔</a></td>
+      <td align="center" valign="top" width="14.28%"><a href="https://github.com/JSn1nj4"><img src="https://avatars1.githubusercontent.com/u/5084820?v=4?s=100" width="100px;" alt="Elliot Derhay"/><br /><sub><b>Elliot Derhay</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=JSn1nj4 " title="Code">💻</a> <a href="https://github.com/hackgvl/hackgreenville-com/issues?q=author%3AJSn1nj4 " title="Bug reports">🐛</a> <a href="#ideas-JSn1nj4 " title="Ideas, Planning, & Feedback">🤔</a> <a href="https://github.com/hackgvl/hackgreenville-com/commits?author=JSn1nj4" title="Documentation">📖</a></td>
       <td align="center" valign="top" width="14.28%"><a href="http://twitter.com/fancybike"><img src="https://avatars0.githubusercontent.com/u/4888730?v=4?s=100" width="100px;" alt="Pamela"/><br /><sub><b>Pamela</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=pamelawoodbrowne" title="Documentation">📖</a> <a href="#content-pamelawoodbrowne" title="Content">🖋</a> <a href="#ideas-pamelawoodbrowne" title="Ideas, Planning, & Feedback">🤔</a> <a href="#eventOrganizing-pamelawoodbrowne" title="Event Organizing">📋</a></td>
     </tr>
     <tr>
@@ -62,7 +62,6 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <tr>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/AbolfazlAkhtari"><img src="https://avatars.githubusercontent.com/u/68465524?v=4?s=100" width="100px;" alt="Abolfazl Akhtari"/><br /><sub><b>Abolfazl Akhtari</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=AbolfazlAkhtari" title="Code">💻</a></td>
       <td align="center" valign="top" width="14.28%"><a href="https://github.com/Alex-Grimes"><img src="https://avatars.githubusercontent.com/u/66704965?v=4?s=100" width="100px;" alt="Alexander Grimes"/><br /><sub><b>Alexander Grimes</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=Alex-Grimes" title="Code">💻</a></td>
-      <td align="center" valign="top" width="14.28%"><a href="https://github.com/JSn1nj4"><img src="https://avatars.githubusercontent.com/u/5084820?v=4?s=100" width="100px;" alt="JSn1nj4"/><br /><sub><b>JSn1nj4</b></sub></a><br /><a href="https://github.com/hackgvl/hackgreenville-com/commits?author=JSn1nj4" title="Documentation">📖</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
- Adds a new EVENTS_API.md with examples, limitations, and links to .env server variables
- Updates CONTRIBUTING.md to note the .env files and some explanation
- Add comments to the .env.example and .env.docker since there are some confusing variables related to the maximum days in the past and future that the Laravel impoter will import events from Meetup and Eventbrite.
- Added a link from the README to the new EVENTS_API.md
- Fix an issue where JSn1nj4 was added twice by All Contributors