### PR TITLE
Docs: Add contributor notes to the Events API docs pointing at Meetup and Eventbrite docs

### DIFF
--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -48,6 +48,22 @@ By default, results are returned in JSON format.
 }
 ```
 
+## Contributor Notes
+These notes are specifically for those helping develop the _Events API_.
+
+### Meetup.com
+* Wayback Machine has copies of the old v2 REST API docs, which were removed and redirected when their [GraphQL API too over](https://github.com/hackgvl/hackgreenville-com/issues/212).
+* [v2 REST API - GET /events](https://web.archive.org/web/20170709041824/http://www.meetup.com/meetup_api/docs/2/events/)
+* [v2 REST API - GET /groups](https://web.archive.org/web/20170709041556/http://www.meetup.com/meetup_api/docs/2/groups/)
+* Examples
+  * [GET upcoming events for one group / org](https://api.meetup.com/hack-greenville/events?&sign=true&photo-host=public)
+  * [GET past events for one group / org](https://api.meetup.com/hack-greenville/events?&sign=true&photo-host=public&status=past)
+
+### Eventbrite
+* [Eventbrite API Docs](http://developer.eventbrite.com/doc/)
+* [Examples of making requests to the Eventbrite API](https://github.com/hackgvl/hackgreenville-com/issues/217#issuecomment-802212633)
+* [Example "events" response using a test Eventbrite API key](https://www.eventbriteapi.com/v3/events/10584525601/?token=BKKRDKVUVRC5WG4HAVLT)
+
 ## Kudos to Past Contributors
 * Thanks to @Nunie123 for the initial development, and to @ramona-spence for sustaining the [previous Python implementation](https://github.com/hackgvl/events-api).
 * Thanks to @bogdankharchenko for migrating the Python implementation to PHP / Laravel


### PR DESCRIPTION
This includes active docs from the services, links to old internal notes, and Wayback Machine links to the old v2 REST Meetup docs.