### PR TITLE
Fix: Add --no-dev to the Deploy Script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -485,9 +485,9 @@ Some examples of good branch names are:
    Keep your commit messages short. You can always add additional information in the description of the commit message.
 
 5. Push the new branch to your fork / origin. For example, if the name of your branch is `docs/typos-in-readme`, then your command should be:
-`sh
+   ```sh
     git push origin docs/typos-in-readme
-    `
+    ```
 </details>
 
 <details><summary>Step 3: Proposing a Pull Request (PR)</summary>

--- a/scripts/handle-deploy-update.sh
+++ b/scripts/handle-deploy-update.sh
@@ -15,7 +15,7 @@ echo "JavaScript dependencies installation completed."
 
 # Install the PHP dependencies
 echo "Installing PHP dependencies..."
-composer install
+composer install --no-dev
 echo "PHP dependencies installation completed."
 
 # Run database migrations and seed the database


### PR DESCRIPTION
Per earlier conversation, https://github.com/hackgvl/hackgreenville-com/issues/233#issuecomment-1964348477 we agreed the deploy script should have --no-dev to avoid installing any dev packages on stage or production.

Also, fixed a minor typo in CONTRIBUTING.md.