### PR TITLE
Use Vite more flexibly

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,5 +69,17 @@ EVENT_IMPORTER_MAX_DAYS_IN_FUTURE=180
 # in the past will be returned.  That is, start_date = {today's date - EVENTS_API_DEFAULT_DAYS}
 EVENTS_API_DEFAULT_DAYS=1
 
-If you want to enable Telescope, you will need to set this to true and uncomment the line below.
-# TELESCOPE_ENABLED=true
+# If you want to enable Telescope, you will need to set this to true and uncomment the line below.
+#TELESCOPE_ENABLED=true
+
+# Give Vite a path to local cert and key files if you want HTTPS during development.
+# Vite docs: https://vitejs.dev/config/server-options#server-https
+# Node reference: https://nodejs.org/api/https.html#https_https_createserver_options_requestlistener
+#VITE_HTTPS_CERT=
+#VITE_HTTPS_KEY=
+# Vite's default development settings for this project are included here
+#VITE_SERVER_HOST='0.0.0.0'
+#VITE_SERVER_POLLING=true
+# Set the client-side host if different than `VITE_SERVER_HOST`,
+# such as when developing inside a container.
+#VITE_SERVER_HMR_HOST=

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,51 +1,82 @@
-import {defineConfig} from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import laravel from 'laravel-vite-plugin';
 import {ViteImageOptimizer} from "vite-plugin-image-optimizer";
+import * as fs from 'fs'
 
-export default defineConfig({
-    plugins: [
-        laravel({
-            input: [
-                'resources/css/app.css',
-                'resources/sass/app.scss',
-                'resources/js/app.js',
-            ],
-            refresh: true,
-        }),
-        ViteImageOptimizer({
-            test: /\.(jpe?g|png|gif|tiff|webp|svg|avif)$/i,
-            includePublic: true,
-            ansiColors: true,
-            png: {
-                // https://sharp.pixelplumbing.com/api-output#png
-                quality: 85,
+export default defineConfig(({mode}) => {
+    Object.assign(process.env, loadEnv(mode, process.cwd()))
+
+    const {
+        VITE_SERVER_HMR_HOST = '0.0.0.0',
+        VITE_SERVER_HOST = '0.0.0.0',
+        VITE_SERVER_POLLING = true,
+    } = process.env
+
+    return {
+        plugins: [
+            laravel({
+                input: [
+                    'resources/css/app.css',
+                    'resources/sass/app.scss',
+                    'resources/js/app.js',
+                ],
+                refresh: true,
+            }),
+            ViteImageOptimizer({
+                test: /\.(jpe?g|png|gif|tiff|webp|svg|avif)$/i,
+                includePublic: true,
+                ansiColors: true,
+                png: {
+                    // https://sharp.pixelplumbing.com/api-output#png
+                    quality: 85,
+                },
+                jpeg: {
+                    // https://sharp.pixelplumbing.com/api-output#jpeg
+                    quality: 80,
+                },
+                jpg: {
+                    // https://sharp.pixelplumbing.com/api-output#jpeg
+                    quality: 80,
+                },
+                tiff: {
+                    // https://sharp.pixelplumbing.com/api-output#tiff
+                    quality: 100,
+                },
+                webp: {
+                    // https://sharp.pixelplumbing.com/api-output#webp
+                    lossless: true,
+                },
+                avif: {
+                    // https://sharp.pixelplumbing.com/api-output#avif
+                    lossless: true,
+                },
+            }),
+        ],
+        server: {
+            hmr: {
+                host: VITE_SERVER_HMR_HOST,
             },
-            jpeg: {
-                // https://sharp.pixelplumbing.com/api-output#jpeg
-                quality: 80,
+            host: VITE_SERVER_HOST,
+            https: httpsCertConfig(process.env),
+            watch: {
+                usePolling: VITE_SERVER_POLLING,
             },
-            jpg: {
-                // https://sharp.pixelplumbing.com/api-output#jpeg
-                quality: 80,
-            },
-            tiff: {
-                // https://sharp.pixelplumbing.com/api-output#tiff
-                quality: 100,
-            },
-            webp: {
-                // https://sharp.pixelplumbing.com/api-output#webp
-                lossless: true,
-            },
-            avif: {
-                // https://sharp.pixelplumbing.com/api-output#avif
-                lossless: true,
-            },
-        }),
-    ],
-    server: {
-        host: '0.0.0.0',
-        watch: {
-            usePolling: true,
         },
-    },
+    }
 });
+
+function httpsCertConfig(env) {
+    const {
+        VITE_HTTPS_CERT = null,
+        VITE_HTTPS_KEY = null
+    } = env
+
+    if (!VITE_HTTPS_CERT && !VITE_HTTPS_KEY) return false
+
+    if (!fs.existsSync(VITE_HTTPS_CERT) && !fs.existsSync(VITE_HTTPS_KEY)) return false
+
+    return {
+        cert: fs.readFileSync(VITE_HTTPS_CERT),
+        key: fs.readFileSync(VITE_HTTPS_KEY),
+    }
+}


### PR DESCRIPTION
This makes local development with Vite a little more flexible by providing a few new environment vars.

- `VITE_SERVER_HOST`: This is the hostname used by the project. By default, this is just `'0.0.0.0'` as it was before.
- `VITE_SERVER_HMR_HOST`: This is used if you want to point Vite's client to a different hostname. This is useful for containerized development, where the internal address might be `0.0.0.0` (allowing the local app to be visible outside the container) but the container has a different external address (`hackgreenville.local` or similar).
- `VITE_SERVER_POLLING`: In this project, Vite's polling is `true` by default. You can disable it by setting this to `false`.

These 2 are for using HTTPS in local development. They should point to certificate and key files on your filesystem.
```
VITE_HTTPS_CERT
VITE_HTTPS_KEY
```
For this to work, both must be set and Vite must be able to read both files.

___
Closes #234 