### PR TITLE
Remove Telescope auto-loading from config/app.php since it's now loading dynamically

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -197,7 +197,6 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\Filament\AdminPanelProvider::class,
         App\Providers\RouteServiceProvider::class,
-        App\Providers\TelescopeServiceProvider::class,
     ],
 
     /*


### PR DESCRIPTION
#242 now loads app/Providers/AppServiceProvider.php if Telescope is enabled in the .env environment variables.

This autoloading was added before we decided to allow Telescope to be run based on configuration.

Since we use composer install --no-dev on stage and production, [Telescope is not installed and this would cause a composer error as previously documented](https://github.com/hackgvl/hackgreenville-com/pull/236#issuecomment-2018227444).

Fixeds the ``Script @php artisan package:discover handling the post-autoload-dump event returned with error code 1`` Composer issue.