### PR TITLE
Add support for slugs and description for Orgs

### DIFF
--- a/app/Console/Commands/MigrateOrgSlugsCommand.php
+++ b/app/Console/Commands/MigrateOrgSlugsCommand.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Org;
+use Glhd\ConveyorBelt\IteratesQuery;
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+
+class MigrateOrgSlugsCommand extends Command
+{
+    use IteratesQuery;
+
+    protected $signature = 'migrate:org-slugs';
+
+    protected $description = 'Extracts slug from the URL. Should only be ran one time.';
+
+    public function query()
+    {
+        return Org::query();
+    }
+
+    public function handleRow(Org $org)
+    {
+        $org->update([
+            'slug' => Str::afterLast($org->path, '/'),
+        ]);
+    }
+}

--- a/app/Filament/Resources/OrgResource.php
+++ b/app/Filament/Resources/OrgResource.php
@@ -35,6 +35,15 @@ class OrgResource extends Resource
                             ->columnSpanFull()
                             ->maxLength(255),
 
+                        Forms\Components\TextInput::make('slug')
+                            ->required()
+                            ->columnSpanFull()
+                            ->maxLength(255),
+
+                        Forms\Components\Textarea::make('description')
+                            ->required()
+                            ->columnSpanFull(),
+
                         Forms\Components\TextInput::make('city')
                             ->required()
                             ->maxLength(255),

--- a/database/migrations/2024_04_26_122917_add_slug_and_description_to_orgs_table.php
+++ b/database/migrations/2024_04_26_122917_add_slug_and_description_to_orgs_table.php
@@ -5,22 +5,22 @@ use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration {
-	public function up(): void
-	{
-		Schema::table('orgs', function(Blueprint $table) {
-			$table->string('slug')->nullable()->after('id');
-		});
+    public function up(): void
+    {
+        Schema::table('orgs', function (Blueprint $table) {
+            $table->string('slug')->nullable()->after('id');
+        });
 
-		Schema::table('orgs', function(Blueprint $table) {
-			$table->longText('description')->nullable()->after('title');
-		});
-	}
+        Schema::table('orgs', function (Blueprint $table) {
+            $table->longText('description')->nullable()->after('title');
+        });
+    }
 
-	public function down(): void
-	{
-		Schema::table('orgs', function(Blueprint $table) {
-			$table->dropColumn('slug');
-			$table->dropColumn('description');
-		});
-	}
+    public function down(): void
+    {
+        Schema::table('orgs', function (Blueprint $table) {
+            $table->dropColumn('slug');
+            $table->dropColumn('description');
+        });
+    }
 };

--- a/database/migrations/2024_04_26_122917_add_slug_and_description_to_orgs_table.php
+++ b/database/migrations/2024_04_26_122917_add_slug_and_description_to_orgs_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+	public function up(): void
+	{
+		Schema::table('orgs', function(Blueprint $table) {
+			$table->string('slug')->nullable()->after('id');
+		});
+
+		Schema::table('orgs', function(Blueprint $table) {
+			$table->longText('description')->nullable()->after('title');
+		});
+	}
+
+	public function down(): void
+	{
+		Schema::table('orgs', function(Blueprint $table) {
+			$table->dropColumn('slug');
+			$table->dropColumn('description');
+		});
+	}
+};


### PR DESCRIPTION
This adds a column for slug and description.  We can determine the slug - but we do not have a description at the moment.  It can either be manually entered or we need another command to fill in description.

### After deploy steps

`php artisan migrate:org-slugs`