### PR TITLE
Scroll calendar to current week on first load

### DIFF
--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -11,8 +11,9 @@
 
 @section('js')
     <script type="text/javascript">
-
         document.addEventListener('DOMContentLoaded', function () {
+            let firstRender = true;
+
             const calendarEl = document.getElementById('calendar');
 
             const calendar = new FullCalendar.Calendar(calendarEl, {
@@ -30,6 +31,8 @@
                         $(".loading").fadeIn('fast');
                     } else {
                         $(".loading").fadeOut('fast');
+
+                        if (firstRender) setTimeout(maybeMoveToCurrentWeek, 100);
                     }
                 },
                 eventClick: function (info) {
@@ -89,6 +92,28 @@
                     info.el.style.borderColor = info.el.style.borderColor == 'red' ? 'black' : 'red';
                 }
             });
+
+            function maybeMoveToCurrentWeek() {
+                let layoutRoot = calendarEl.querySelector('.fc-dayGridMonth-view');
+
+                if (layoutRoot === null) {
+                    console.warn('layout root not found');
+                    return;
+                }
+
+                let thisWeek = layoutRoot.querySelector('.fc-today').closest('.fc-week');
+
+                // current week can be found at end of last month, within this month, or beginning of next month
+                if (thisWeek === null) {
+                    console.warn('Current week is not on this page.');
+                    return;
+                }
+
+                document.querySelector('.fc-scroller')
+                    .scrollTo(0, thisWeek.offsetTop);
+
+                firstRender = false;
+            }
 
             calendar.render();
         });

--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -110,7 +110,10 @@
                 }
 
                 document.querySelector('.fc-scroller')
-                    .scrollTo(0, thisWeek.offsetTop);
+                    .scrollTo({
+                        top: thisWeek.offsetTop,
+                        behavior: 'smooth',
+                    });
 
                 firstRender = false;
             }


### PR DESCRIPTION
The basic requirements are listed [here](https://github.com/hackgvl/hackgreenville-com/issues/253#issuecomment-2081201739)

> * Scroll to current on page load
> * Reset to top on next/previous
> * Only do this on the month view

Attempting to move to the current week happens from Full Calendar's `loading` hook, which seems to fire both when loading and after loading is completed.

It will only happen on first render using a local var. This is because this hook is fired on first load and every time someone navigates using the calendar's "Next"/"Previous" buttons.

Re-centering also doesn't happen if someone manually navigates back to the current month instead of reloading the page.

Resolves #253