### PR TITLE
Set favicon.png instead of the missing favicon.ico in the Filament admin panel

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -41,6 +41,7 @@ class AdminPanelProvider extends PanelProvider
                 Widgets\AccountWidget::class,
             ])
             ->middleware(['filament-web'])
-            ->authMiddleware(['filament-auth']);
+            ->authMiddleware(['filament-auth'])
+            ->favicon(asset('favicon.png'));
     }
 }


### PR DESCRIPTION
I have too many tabs open....and missing favicons hurts the brain.