### PR TITLE
Feature: Add a dynamic meta description to each the organizations details pages

### DIFF
--- a/resources/views/orgs/show.blade.php
+++ b/resources/views/orgs/show.blade.php
@@ -1,6 +1,7 @@
 @extends('layouts.app')
 
 @section('title', $org->title)
+@section('description', 'Highlights of the '. $org->title . ' organization of '. $org->city . ', SC, including upcoming events, organizer, and history.')
 
 @section('content')
     <div class="container">


### PR DESCRIPTION
This adds meta descriptions to the Blade files for organization pages like https://hackgreenville.com/orgs/hackgreenville

This looks like a reasonable place to define these values, but open to suggestions.

Closes #288 