### PR TITLE
Allow organizations description fields to display HTML

### DIFF
--- a/resources/views/orgs/show.blade.php
+++ b/resources/views/orgs/show.blade.php
@@ -9,7 +9,7 @@
         </h1>
 
         <blockquote>
-            {{ $org->description }}
+            {!! $org->description !!}
         </blockquote>
 
         <table class="table">


### PR DESCRIPTION
Allow organizations description fields to display HTML. 

Presumably this will always be admin only fields, so we do not have XSS concerns, but we could still sanitize the input if we are worried about it.

Close #291 