### PR TITLE
Increase the connection timeout for Meetup from 10 to 20 seconds

### DIFF
--- a/app-modules/event-importer/src/Services/Concerns/AbstractEventHandler.php
+++ b/app-modules/event-importer/src/Services/Concerns/AbstractEventHandler.php
@@ -32,7 +32,9 @@ abstract class AbstractEventHandler
 
     public function eventExistsOnService(Event $event): bool
     {
-        return Http::get($event->url)->successful();
+        return Http::get($event->url)
+            ->connectTimeout(20)
+            ->successful();
     }
 
     /** @return array{int, Collection<EventData>} */

--- a/app-modules/event-importer/src/Services/MeetupRestHandler.php
+++ b/app-modules/event-importer/src/Services/MeetupRestHandler.php
@@ -32,6 +32,7 @@ class MeetupRestHandler extends AbstractEventHandler
                 'no_earlier_than' => now()->subDays($this->max_days_in_past)->startOfDay()->format('Y-m-d\TH:i:s'),
                 'no_later_than' => now()->addDays($this->max_days_in_future)->endOfDay()->format('Y-m-d\TH:i:s'),
             ])
+            ->connectTimeout(20)
             ->throw()
             ->get("{$this->org->service_api_key}/events");
 


### PR DESCRIPTION
Not sure what's causing the delay, but we'll see if it keeps happening and perhaps this will prevent the logs from throwing a lot of timeout errors.

Closes #301 