### PR TITLE
Add Code of Conduct Page. Add links to CofC in Templates and Other Pages

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -28,6 +28,16 @@ class HomeController extends Controller
         return view('about');
     }
 
+    /**
+     * Show the application Code of Conduct page.
+     *
+     * @return View
+     */
+    public function code_of_conduct()
+    {
+        return view('code-of-conduct');
+    }
+
     public function testing()
     {
         return view('testing');

--- a/app/Http/Controllers/LabsController.php
+++ b/app/Http/Controllers/LabsController.php
@@ -9,13 +9,6 @@ class LabsController extends Controller
         $remove_space = true;
         $projects = [
             [
-                'name' => __('Organizations API'),
-                'description' => __('Public API for organization information'),
-                'link' => 'https://data.openupstate.org/organizations',
-                'linkType' => 'website',
-                'status' => 'active',
-            ],
-            [
                 'name' => __('Events API'),
                 'description' => __('Public API for tech event information'),
                 'link' => 'https://github.com/hackgvl/OpenData',

--- a/resources/views/about.blade.php
+++ b/resources/views/about.blade.php
@@ -23,8 +23,8 @@
         <p class="lead-text">In Nov. 2023, HackGreenville established a collaborative relationship with <a href="https://refactorgvl.com/" target="refactorgvl">RefactorGVL</a>, a local 501(c)(3) non-profit, to further their mission of elevating the tech community in the Upstate. This collaboration provides infrastructure, fiscal sponsorship, and other support services to HackGreenville as it serves the local workforce.</p>
         <p class="lead-text">Here's a snapshot of our community's purpose, mission, vision, and culture:</p>
         <h2 class="section-heading">Our Purpose</h2>
-        <p class="lead-text">We are here to nurture personal growth amongst Greenville, SC's vibrant community of
-            "hackers" and beyond.</p>
+        <p class="lead-text">We are here to nurture personal growth among the vibrant community of
+            "hackers" in Greenville, SC and the surrounding Upstate area.</p>
         <h2 class="section-heading">Our Mission</h2>
         <p class="lead-text">Through our <a href="/join-slack" class="highlight-link">online community</a> and <a
                 href="/" class="highlight-link">discovery
@@ -35,9 +35,12 @@
             tech enthusiasts exploring the area's vibrant "hacker" culture and opportunities.</p>
         <h2 class="section-heading">Our Culture and Guiding Principles</h2>
         <ul class="values-list">
+            <li>We expect everyone to abide by the <a href="{{route('code-of-conduct')}}">Code of Conduct</a> within our Slack and at in-person events.</li>
+            <li>We exist to nurture personal growth, not to bring people down.
+                Constructive debate, even "Tabs" or "Spaces", is welcome, but please do not harrass or provoke.
+            </li>
             <li>We welcome all hackers, makers, and tinker types. Our community extends beyond just software.</li>
             <li>Be respectful. Egos and biases have no place here.</li>
-            <li>Enjoy the journey. Trolling isn't tolerated.</li>
             <li>Pay it forward. Remember, your knowledge comes from others.</li>
             <li>Give more than you take. This isn't a community for selfish pursuits.</li>
         </ul>

--- a/resources/views/code-of-conduct.blade.php
+++ b/resources/views/code-of-conduct.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.app')
+
+@section('title', 'HackGreenville Code of Conduct')
+@section('description', 'The Code of Conduct for the HackGreenville community.')
+
+@section('content')
+    <div id="about-us" class="container">
+        <h1 class="title-heading">HackGreenville Code of Conduct</h1>
+
+        <p>HackGreenville is dedicated to providing a welcoming and harassment-free community and events for everyone. We do not tolerate harassment of our community members in any form.</p>
+        <p>The following Code of Conduct extends to all HackGreenville online activity (our Slack community, the HackGreenville website, the HackGreenville Github, etc) and in-person events. Anyone found to be violating these rules may be sanctioned or expelled from the community online platforms or events at the discretion of the moderators and event organizers.</p>
+        <p>Harassment includes offensive verbal comments related to gender identity and expression, sexual orientation, disability, physical appearance, race, ethnicity, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing images or recordings, sustained disruption of online discussion, talks, or other events, inappropriate physical contact, unwelcome sexual attention, spam, personal attacks, trolling or other anti-social behavior. Participants asked to stop any harassing behavior (by organizers or anyone) are expected to comply immediately.</p>
+        <p>If a participant engages in harassing behavior, the HackGreenville moderators and/or event organizers may take any action they deem appropriate, including warning the offender or expulsion from the virtual platform or event. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a moderator of HackGreenville and/or event organizer immediately.</p>
+        <p>HackGreenville board, moderators and event organizers will be happy to help participants contact security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe in our virtual platforms and at our events. We value your participation and strive to provide the most welcoming community experiences.</p>
+        <p>Please feel free to contact us at coc [at] hackgreenville.com or by filling out our <a href="https://forms.gle/HZSnPHfSJ3V2wRUf8" rel="nofollow">Code of Conduct form</a>.</p>
+        <p><small>Hat-tip to <a href="https://minnestar.org/" rel="nofollow">Minnestar</a> for the inspiration.</small></p>
+
+    </div>
+@endsection

--- a/resources/views/layouts/footer.blade.php
+++ b/resources/views/layouts/footer.blade.php
@@ -25,22 +25,12 @@
                     </div>
 
                     <div class="d-flex flex-column align-middle h-100">
-                        <h4 class="mb-4">Some technology we like</h4>
+                        <h4 class="mb-4">Built with Laravel</h4>
 
                         <div class="text-center footer-technology-icons">
                             <a href="https://laravel.com" class="footer-technology-icon-wrapper" rel="nofollow">
                                 <img src="{{url('img/icons/laravel-226015.png')}}" class="footer-technology-icon"
                                      alt="Laravel"/>
-                            </a>
-                            <a href="https://www.djangoproject.com" class="footer-technology-icon-wrapper"
-                               rel="nofollow">
-                                <img src="{{url('img/icons/django.jpg')}}" class="footer-technology-icon" alt="Django"/>
-                            </a>
-                            <a href="https://nuxtjs.org" class="footer-technology-icon-wrapper" rel="nofollow">
-                                <img src="{{url('img/icons/nuxt.png')}}" class="footer-technology-icon" alt="NuxtJS"/>
-                            </a>
-                            <a href="https://nextjs.org/" class="footer-technology-icon-wrapper" rel="nofollow">
-                                <img src="{{url('img/icons/nextjs.png')}}" class="footer-technology-icon" alt="NextJS"/>
                             </a>
                         </div>
                     </div>
@@ -69,6 +59,12 @@
                                 <a class="@if(Route::is('join-slack.*')) active @endif" href="/join-slack">
                                     <i class="fa fa-slack"></i>
                                     {{__('Join Slack')}}
+                                </a>
+                            </li>
+                            <li>
+                                <a class="@if(Route::is('code-of-conduct.*')) active @endif" href="{{route('code-of-conduct')}}">
+                                    <i class="fa fa-check"></i>
+                                    {{ __('Code of Conduct') }}
                                 </a>
                             </li>
                             <li>

--- a/resources/views/slack/sign-up.blade.php
+++ b/resources/views/slack/sign-up.blade.php
@@ -11,13 +11,13 @@
                     <h1>{{ __('Sign up for HackGreenville!') }}</h1>
 
                     <h4>
-                        <a href="https://hackgreenville.slack.com" class="badge badge-pill btn-success p-3" rel="noreferrer" target="_blank">
+                        <a href="https://hackgreenville.slack.com" class="badge badge-pill btn-success p-3" rel="nofollow" target="_blank">
                             Already Signed Up? Log In to Slack
                         </a>
                     </h4>
 
                     <p class="summary">
-                        {{ __('Ready to get started? Fill out the sign up form below and we\'ll add you as soon as possible!') }}
+                        {{ __('Ready to get started? Fill out the form below and we\'ll add you as soon as possible!') }}
                     </p>
                 </div>
             </div>
@@ -33,7 +33,7 @@
 
                     {{ aire()->input('name', __('Full Name'))->required() }}
                     {{ aire()->email('contact', __('Email'))->required() }}
-                    {{ aire()->textArea('reason', __('What do you do in the Upstate?'))->rows(4)->placeholder(__('What is it that interests you? What kinds of things are you involved in here? If you are not from the Upstate and don\'t plan to be, you might find another group better suited for you.')) }}
+                    {{ aire()->textArea('reason', __('To help us weed out spam, please confirm you are a real person.'))->rows(4)->placeholder(__('What interests you about HackGreenville? What connections do you have to the Upstate of South Carolina?')) }}
 
                 </div>
             </div>
@@ -41,11 +41,10 @@
                 <div class="col-md-5">
                     <p>The Rules of HackGreenville are simple:</p>
                     <ul class="text-left">
-                        <li>
-                            <strong>Be nice:</strong>
-                            We're a community that helps one another regardless of Gender,
-                            Religion, Political Party, Programming Language, Tabs or Spaces... If you
-                            try to provoke fights you will be removed.
+                        <li><strong>Everyone agrees to abide by the <a href="{{route('code-of-conduct')}}" target="_blank">Code of Conduct</a></strong>
+                          within our Slack and at in-person events.
+                            We <a href="{{route('about')}}" target="_blank">exist to nurture personal growth</a>, not to bring people down.
+                            Constructive debate, even "Tabs" or "Spaces", is welcome, but please do not harrass or provoke.
                         </li>
                         <li>
                             <strong>Be considerate:</strong>

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ Route::get('/labs', [LabsController::class, 'index'])->name('labs.index');
 Route::get('/hg-nights', [HGNightsController::class, 'index'])->name('hg-nights.index');
 Route::get('/give', [GiveController::class, 'index'])->name('give');
 Route::get('/about', [HomeController::class, 'about'])->name('about');
+Route::get('/code-of-conduct', [HomeController::class, 'code_of_conduct'])->name('code-of-conduct');
 
 Route::get('/orgs', [OrgsController::class, 'index'])->name('orgs.index');
 Route::get('/orgs/{org:slug}', [OrgsController::class, 'show'])->name('orgs.show');


### PR DESCRIPTION
New page and route is /code-of-conduct

Tweak Join Slack page, About page, and Labs pages.

Closes #313 

Not related, but I removed the old Orgs API from the Labs page in this PR too, since that was linking to a 301 redirect of the old orgs page.

## CofC Page
![image](https://github.com/hackgvl/hackgreenville-com/assets/1777776/9afa84cf-d4e9-4211-95f8-1ab3c3189fb1)

## Footer link
![image](https://github.com/hackgvl/hackgreenville-com/assets/1777776/fdc7ed2e-d851-4ac6-aecb-5ac21d5b476d)

## Join Slack Form Tweaks
![image](https://github.com/hackgvl/hackgreenville-com/assets/1777776/c4e0ca4a-30a2-4010-bb00-444dc22818a6)

## About Page Tweaks
![image](https://github.com/hackgvl/hackgreenville-com/assets/1777776/d54f870f-b1c7-4d11-9bf5-344a5363aabe)
