### PR TITLE
Strict Model mode

### DIFF
--- a/app-modules/api/src/Resources/Events/V0/EventResource.php
+++ b/app-modules/api/src/Resources/Events/V0/EventResource.php
@@ -16,7 +16,7 @@ class EventResource extends JsonResource
         return [
             'event_name' => $this->resource->event_name,
             'group_name' => $this->resource->group_name,
-            'group_url' => $this->resource->organization->home_page,
+            'group_url' => $this->resource->organization->uri,
             'url' => $this->resource->url,
             'time' => $this->resource->active_at->toISOString(),
             'tags' => $this->resource->organization->tags->first()?->id ?? '',

--- a/app-modules/api/src/Resources/Orgs/V0/OrgResource.php
+++ b/app-modules/api/src/Resources/Orgs/V0/OrgResource.php
@@ -21,7 +21,7 @@ class OrgResource extends JsonResource
             'field_event_service' => $this->resource->service,
             'field_events_api_key' => $this->resource->service_api_key,
             'field_focus_area' => $this->resource->focus_area,
-            'field_homepage' => $this->resource->home_page,
+            'field_homepage' => $this->resource->uri,
             'field_event_calendar_homepage' => $this->resource->event_calendar_uri,
             'field_primary_contact_person' => $this->resource->primary_contact_person,
             'field_org_status' => $this->resource->status,

--- a/app-modules/api/tests/Feature/EventApiV0Test.php
+++ b/app-modules/api/tests/Feature/EventApiV0Test.php
@@ -27,7 +27,7 @@ class EventApiV0Test extends DatabaseTestCase
                 [
                     'event_name' => $event->event_name,
                     'group_name' => $event->group_name,
-                    'group_url' => $event->organization->home_page,
+                    'group_url' => $event->organization->uri,
                     'url' => $event->url,
                     'time' => $event->active_at->toISOString(),
                     'tags' => $event->organization->tags->first()->id,

--- a/app-modules/api/tests/Feature/OrganizationsApiV0Test.php
+++ b/app-modules/api/tests/Feature/OrganizationsApiV0Test.php
@@ -28,7 +28,7 @@ class OrganizationsApiV0Test extends DatabaseTestCase
                     'field_event_service' => $org->service,
                     'field_events_api_key' => $org->service,
                     'field_focus_area' => $org->focus_area,
-                    'field_homepage' => $org->home_page,
+                    'field_homepage' => $org->uri,
                     'field_org_status' => $org->status->value,
                     'field_primary_contact_person' => $org->primary_contact_person,
                     'field_organization_type' => $org->organization_type,

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -36,7 +36,6 @@ use RuntimeException;
  * @property string|null $event_uuid
  * @property-read string $active_at_ftm
  * @property-read string $g_cal_url
- * @property-read Carbon|string $local_active_at
  * @property-read string $short_description
  * @property-read string $state
  * @property-read string $status
@@ -93,13 +92,6 @@ class Event extends BaseModel
         'service_id' => 'string',
         'service' => EventServices::class,
         'visibility' => EventVisibility::class,
-    ];
-
-    protected $appends = [
-        'short_description',
-        'title',
-        'active_at_ftm',
-        'status',
     ];
 
     public function getUniqueIdentifierAttribute(): bool|string
@@ -207,11 +199,6 @@ class Event extends BaseModel
         ]));
 
         return 'https://www.google.com/calendar/event?action=TEMPLATE&' . $query;
-    }
-
-    public function getLocalActiveAtAttribute(): Carbon|string
-    {
-        return $this->active_at->tz(config('app.timezone'));
     }
 
     public function getShortDescriptionAttribute(): string

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -34,9 +34,6 @@ use RuntimeException;
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property \Illuminate\Support\Carbon|null $expire_at
  * @property string|null $event_uuid
- * @property-read string $active_at_ftm
- * @property-read string $g_cal_url
- * @property-read string $short_description
  * @property-read string $state
  * @property-read string $status
  * @property-read string $title

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -198,27 +198,12 @@ class Event extends BaseModel
             'trp' => false,
         ]));
 
-        return 'https://www.google.com/calendar/event?action=TEMPLATE&' . $query;
-    }
-
-    public function getShortDescriptionAttribute(): string
-    {
-        return str_limit($this->description);
-    }
-
-    public function getActiveAtFtmAttribute(): string
-    {
-        return $this->active_at->diffForHumans();
-    }
-
-    public function getTitleAttribute(): string
-    {
-        return $this->event_name;
+        return 'https://www.google.com/calendar/event?action=TEMPLATE&'.$query;
     }
 
     public function doesNotExistOnEventService(): bool
     {
-        return ! $this->organization
+        return !$this->organization
             ->getEventHandler()
             ->eventExistsOnService($this);
     }
@@ -231,7 +216,7 @@ class Event extends BaseModel
     protected function expireAt(): Attribute
     {
         return Attribute::make(
-            get: fn ($value) => Carbon::parse($value ?? $this->active_at->copy()->addHours(2)),
+            get: fn($value) => Carbon::parse($value ?? $this->active_at->copy()->addHours(2)),
         );
     }
 }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -198,12 +198,12 @@ class Event extends BaseModel
             'trp' => false,
         ]));
 
-        return 'https://www.google.com/calendar/event?action=TEMPLATE&'.$query;
+        return 'https://www.google.com/calendar/event?action=TEMPLATE&' . $query;
     }
 
     public function doesNotExistOnEventService(): bool
     {
-        return !$this->organization
+        return ! $this->organization
             ->getEventHandler()
             ->eventExistsOnService($this);
     }
@@ -216,7 +216,7 @@ class Event extends BaseModel
     protected function expireAt(): Attribute
     {
         return Attribute::make(
-            get: fn($value) => Carbon::parse($value ?? $this->active_at->copy()->addHours(2)),
+            get: fn ($value) => Carbon::parse($value ?? $this->active_at->copy()->addHours(2)),
         );
     }
 }

--- a/app/Models/Org.php
+++ b/app/Models/Org.php
@@ -30,7 +30,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Illuminate\Support\Carbon|null $updated_at
  * @property \Illuminate\Support\Carbon|null $deleted_at
  * @property-read Category|null $category
- * @property-read mixed $home_page
  * @property-read mixed $url
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Tag> $tags
  * @property-read int|null $tags_count

--- a/app/Models/Venue.php
+++ b/app/Models/Venue.php
@@ -25,7 +25,6 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string|null $country
  * @property-read \Illuminate\Database\Eloquent\Collection<int, \App\Models\Event> $events
  * @property-read int|null $events_count
- * @property-read mixed $state_abbr
  * @property-read State|null $state
  * @method static \Database\Factories\VenueFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder|Venue newModelQuery()

--- a/app/Models/Venue.php
+++ b/app/Models/Venue.php
@@ -73,7 +73,7 @@ class Venue extends Model
 
     public function fullAddress()
     {
-        return "{$this->name} - {$this->address} {$this->city}, {$this->state_abbr} {$this->zipcode}";
+        return "{$this->name} - {$this->address} {$this->city}, {$this->state->abbr} {$this->zipcode}";
     }
 
     public function state()

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Pagination\Paginator;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -25,9 +26,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        Model::preventLazyLoading($this->app->environment('local'));
+        Model::preventLazyLoading( ! App::isProduction());
+        Model::shouldBeStrict( ! App::isProduction());
 
-        if(config('telescope.enabled')) {
+        if (config('telescope.enabled')) {
             $this->app->register(\Laravel\Telescope\TelescopeServiceProvider::class);
             $this->app->register(TelescopeServiceProvider::class);
         }

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -105,7 +105,7 @@
                                                     {{ $event->event_name }}
                                                 </h4>
                                                 <p class="timeline-subtitle h6">
-                                                    {{ $event->organization->name }}
+                                                    {{ $event->organization->title }}
                                                 </p>
                                                 <p>
                                                     <small class="text-muted">


### PR DESCRIPTION
This PR clean's up a few unused getters floating around the code base - also enabled Strict Model mode, which will throw an exception in non-production environments if accessing a non-existing property on a model.