### PR TITLE
Fix Event sorting on Home Screen

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,11 +25,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies
+      - name: install php dependencies
         run: composer install
+      - name: install node dependencies
+        run: yarn install
       - name: copy environment variables to .env
         run: cp .env.ci .env
       - name: migrate database
         run: php artisan migrate --seed
+      - name: Run vite build
+        run: yarn build
       - name: run tests
         run: php artisan test

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -8,7 +8,7 @@ class EventsController extends Controller
 {
     public function index()
     {
-        $months = Event::future()
+        $months = Event::getActive()
             ->published()
             ->with('organization', 'venue.state')
             ->orderBy('active_at')

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -11,7 +11,6 @@ class EventsController extends Controller
         $months = Event::getActive()
             ->published()
             ->with('organization', 'venue.state')
-            ->orderBy('active_at')
             ->get()
             ->groupBy(fn (Event $event) => $event->active_at->format('F Y'));
 

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -9,7 +9,7 @@ class HomeController extends Controller
     public function index()
     {
         return view('index', [
-            'upcoming_events' => Event::future()
+            'upcoming_events' => Event::getActive()
                 ->published()
                 ->with('organization')
                 ->limit(5)

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -116,13 +116,13 @@ class Event extends BaseModel
 
     public function scopeFuture(Builder $query)
     {
-        $query->where('active_at', '>=', DB::raw('NOW()'));
+        $query->where('active_at', '>=', Carbon::now());
     }
 
     public function scopeGetActive(Builder $query): Builder
     {
         return $query
-            ->where('active_at', '>=', DB::raw('NOW()'))
+            ->where('active_at', '>=', Carbon::now())
             ->orderBy('active_at', 'asc');
     }
 

--- a/database/factories/OrgFactory.php
+++ b/database/factories/OrgFactory.php
@@ -19,6 +19,7 @@ class OrgFactory extends Factory
             'title' => $this->faker->word(),
             'path' => $this->faker->url(),
             'city' => $this->faker->city(),
+            'slug' => $this->faker->slug(),
             'focus_area' => $this->faker->word(),
             'primary_contact_person' => $this->faker->word(),
             'organization_type' => $this->faker->word(),

--- a/tests/Feature/Http/Controllers/EventsControllerTest.php
+++ b/tests/Feature/Http/Controllers/EventsControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Event;
+use App\Models\Org;
+use Carbon\Carbon;
+use Tests\DatabaseTestCase;
+
+class EventsControllerTest extends DatabaseTestCase
+{
+  function setUp(): void {
+    parent::setUp();
+
+    Carbon::setTestNow('2020-01-01');
+
+    Event::factory()->create([
+      'event_name' => 'Event 2',
+      'active_at' => '2020-01-02 19:00:00',
+    ]);
+    Event::factory()->create([
+      'event_name' => 'Event 1',
+      'active_at' => '2020-01-02 18:00:00',
+    ]);
+    Event::factory()->create([
+      'event_name' => 'Event 3',
+      'active_at' => '2020-01-02 20:00:00',
+    ]);
+  }
+
+  function test_home_controller_index_method()
+  {
+    $response = $this->get(route('events.index'));
+
+    $response->assertStatus(200);
+    $response->assertSeeInOrder(['Event 1', 'Event 2', 'Event 3']);
+  }
+}

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Event;
+use Carbon\Carbon;
+use Tests\DatabaseTestCase;
+
+class HomeControllerTest extends DatabaseTestCase
+{
+  function setUp(): void {
+    parent::setUp();
+
+    Carbon::setTestNow('2020-01-01');
+
+    Event::factory()->create([
+      'event_name' => 'Event 2',
+      'active_at' => '2020-01-02 19:00:00',
+    ]);
+    Event::factory()->create([
+      'event_name' => 'Event 1',
+      'active_at' => '2020-01-02 18:00:00',
+    ]);
+    Event::factory()->create([
+      'event_name' => 'Event 3',
+      'active_at' => '2020-01-02 20:00:00',
+    ]);
+  }
+
+  function test_home_controller_index_method()
+  {
+    $response = $this->get(route('home'));
+
+    $response->assertStatus(200);
+    $response->assertSeeInOrder(['Event 1', 'Event 2', 'Event 3']);
+  }
+}


### PR DESCRIPTION
Fixes #382 

Changes made:
- Use `getActive` scope when fetching events on `Home` and `Events` pages, this will check both events are active and sort by `active_at` attribute
- Update GitHub Actions check to build with vite before running tests (required to run tests against web controllers)
- Use `Carbon::now()` instead of `DB::raw('NOW()'` because of SQLite does not support this command.