### PR TITLE
Add frontend tests to suite + update documentation around Vite

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,11 +25,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: install dependencies
+      - name: install php dependencies
         run: composer install
+      - name: install node dependencies
+        run: yarn install
       - name: copy environment variables to .env
         run: cp .env.ci .env
       - name: migrate database
         run: php artisan migrate --seed
+      - name: Build website
+        run: yarn build
       - name: run tests
         run: php artisan test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@
       - [Conditional: Install Application Dependencies](#conditional-install-application-dependencies)
       - [Seeding the Application Database](#seeding-the-application-database)
       - [Generating an Application Encryption Key](#generating-an-application-encryption-key)
-      - [Starting Vite Development Server](#starting-vite-development-server)
+      - [Build website](#build-website)
       - [Troubleshooting](#troubleshooting)
       - [Import / Seed Organizations and Events Data](#import--seed-organizations-and-events-data)
 - [Interacting with Your Running App](#interacting-with-your-running-app)
@@ -296,9 +296,15 @@ docker exec -it hackgreenville php artisan key:generate
 
 This command should populate the `APP_KEY` environment variable within your `.env` file.
 
-#### Starting Vite Development Server
+#### Build website
 
-Each time the Docker container is restarted, the Vite development server will need to be running in order for the app's stylesheets to be compiled. You can run the Vite development server by running the following command:
+This project uses Vite to build the website. This includes building out the website's stylesheets and scripts. You can run the following command to generate the production build:
+
+```bash
+docker exec -d hackgreenville yarn build
+```
+
+Alternatively, you can start the Vite development server to listen and compile the latest changes:
 
 ```bash
 docker exec -d hackgreenville yarn dev

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -13,7 +13,7 @@ class HomeControllerTest extends DatabaseTestCase
     Carbon::setTestNow('2020-01-01');
   }
 
-  function test_upcoming_events_sorts_unordered_events()
+  public function test_upcoming_events_sorts_unordered_events()
   {
     Event::factory()->create([
       'event_name' => 'Event 2',
@@ -34,7 +34,7 @@ class HomeControllerTest extends DatabaseTestCase
     $response->assertSeeInOrder(['Event 1', 'Event 2', 'Event 3']);
   }
 
-  function test_upcoming_events_does_not_show_old_events()
+  public function test_upcoming_events_does_not_show_old_events()
   {
     Event::factory()->create([
       'event_name' => 'Event 1',

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\Event;
+use Carbon\Carbon;
+use Tests\DatabaseTestCase;
+
+class HomeControllerTest extends DatabaseTestCase
+{
+  function setUp(): void {
+    parent::setUp();
+
+    Carbon::setTestNow('2020-01-01');
+  }
+
+  function test_upcoming_events_sorts_unordered_events()
+  {
+    Event::factory()->create([
+      'event_name' => 'Event 2',
+      'active_at' => '2020-01-01 19:00:00',
+    ]);
+    Event::factory()->create([
+      'event_name' => 'Event 1',
+      'active_at' => '2020-01-01 18:00:00',
+    ]);
+    Event::factory()->create([
+      'event_name' => 'Event 3',
+      'active_at' => '2020-01-02 12:00:00',
+    ]);
+
+    $response = $this->get(route('home'));
+
+    $response->assertStatus(200);
+    $response->assertSeeInOrder(['Event 1', 'Event 2', 'Event 3']);
+  }
+
+  function test_upcoming_events_does_not_show_old_events()
+  {
+    Event::factory()->create([
+      'event_name' => 'Event 1',
+      'active_at' => '2019-12-31 23:59:59',
+    ]);
+
+    $response = $this->get(route('home'));
+
+    $response->assertStatus(200);
+    $response->assertDontSee('Event 1');
+  }
+}

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -1,49 +1,49 @@
 <?php
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Models\Event;
 use Carbon\Carbon;
 use Tests\DatabaseTestCase;
 
 class HomeControllerTest extends DatabaseTestCase
 {
-  function setUp(): void {
-    parent::setUp();
+    public function setUp(): void
+    {
+        parent::setUp();
 
-    Carbon::setTestNow('2020-01-01');
-  }
+        Carbon::setTestNow('2020-01-01');
+    }
 
-  public function test_upcoming_events_sorts_unordered_events()
-  {
-    Event::factory()->create([
-      'event_name' => 'Event 2',
-      'active_at' => '2020-01-01 19:00:00',
-    ]);
-    Event::factory()->create([
-      'event_name' => 'Event 1',
-      'active_at' => '2020-01-01 18:00:00',
-    ]);
-    Event::factory()->create([
-      'event_name' => 'Event 3',
-      'active_at' => '2020-01-02 12:00:00',
-    ]);
+    public function test_upcoming_events_sorts_unordered_events()
+    {
+        Event::factory()->create([
+            'event_name' => 'Event 2',
+            'active_at' => '2020-01-01 19:00:00',
+        ]);
+        Event::factory()->create([
+            'event_name' => 'Event 1',
+            'active_at' => '2020-01-01 18:00:00',
+        ]);
+        Event::factory()->create([
+            'event_name' => 'Event 3',
+            'active_at' => '2020-01-02 12:00:00',
+        ]);
 
-    $response = $this->get(route('home'));
+        $response = $this->get(route('home'));
 
-    $response->assertStatus(200);
-    $response->assertSeeInOrder(['Event 1', 'Event 2', 'Event 3']);
-  }
+        $response->assertStatus(200);
+        $response->assertSeeInOrder(['Event 1', 'Event 2', 'Event 3']);
+    }
 
-  public function test_upcoming_events_does_not_show_old_events()
-  {
-    Event::factory()->create([
-      'event_name' => 'Event 1',
-      'active_at' => '2019-12-31 23:59:59',
-    ]);
+    public function test_upcoming_events_does_not_show_old_events()
+    {
+        Event::factory()->create([
+            'event_name' => 'Event 1',
+            'active_at' => '2019-12-31 23:59:59',
+        ]);
 
-    $response = $this->get(route('home'));
+        $response = $this->get(route('home'));
 
-    $response->assertStatus(200);
-    $response->assertDontSee('Event 1');
-  }
+        $response->assertStatus(200);
+        $response->assertDontSee('Event 1');
+    }
 }


### PR DESCRIPTION
Building off some of the things that were added into the closed PR https://github.com/hackgvl/hackgreenville-com/pull/383

- Add in a couple frontend tests -- verify site behavior and what appears on screen.
- Update documentation to include a way to compile the production build w/o needing to start the Vite development server each time.