### PR TITLE
Event Importer: Delete Org Events Prior to Event Import

### DIFF
--- a/app-modules/event-importer/src/Console/Commands/ImportEventsCommand.php
+++ b/app-modules/event-importer/src/Console/Commands/ImportEventsCommand.php
@@ -2,11 +2,13 @@
 
 namespace HackGreenville\EventImporter\Console\Commands;
 
+use App\Enums\EventServices;
 use App\Models\Org;
 use Glhd\ConveyorBelt\IteratesIdQuery;
 use HackGreenville\EventImporter\Data\EventData;
 use HackGreenville\EventImporter\Services\ImportEventForOrganization;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class ImportEventsCommand extends Command
@@ -28,19 +30,12 @@ class ImportEventsCommand extends Command
             $handler = $org->getEventHandler();
             $current_page = 1;
 
-            $min_cutoff = now()->subDays(config('event-import-handlers.max_days_in_past'));
-            $max_cutoff = now()->addDays(config('event-import-handlers.max_days_in_future'));
-
-            DB::table('events')
-                ->where('organization_id', '=', $org->id)
-                ->where('active_at', '>', $min_cutoff)
-                ->where('active_at', '<', $max_cutoff)
-                ->delete();
-
             do {
                 [$events, $last_page] = $handler->getPaginatedData($current_page);
 
                 $this->info("Processing Page <{$current_page}> from {$org->service->name} for {$org->title}");
+
+                $this->deleteDuplicateEvents($org, $events);
 
                 /** @var EventData $event_data */
                 foreach ($events as $event_data) {
@@ -51,5 +46,30 @@ class ImportEventsCommand extends Command
 
             } while (++$current_page < $last_page);
         });
+    }
+
+    private function deleteDuplicateEvents(Org $org, Collection $events)
+    {
+        if ( ! $this->shouldDeleteDuplicateEvents($org)) {
+            return;
+        }
+
+        $active_at_dates = $events->pluck('starts_at')->all();
+
+        $events_to_delete = DB::table('events')
+            ->where('organization_id', $org->id)
+            ->whereIn('active_at', $active_at_dates)
+            ->get();
+
+        foreach ($events_to_delete as $event) {
+            $this->info("Deleting duplicate event: {$event->event_name} @ {$event->active_at}");
+
+            DB::table('events')->where('id', $event->id)->delete();
+        }
+    }
+
+    private function shouldDeleteDuplicateEvents(Org $org): bool
+    {
+        return in_array($org->service, [EventServices::MeetupGraphql, EventServices::MeetupRest]);
     }
 }

--- a/app-modules/event-importer/src/Console/Commands/ImportEventsCommand.php
+++ b/app-modules/event-importer/src/Console/Commands/ImportEventsCommand.php
@@ -55,9 +55,11 @@ class ImportEventsCommand extends Command
         }
 
         $active_at_dates = $events->pluck('starts_at')->all();
+        $service_ids = $events->pluck('service_id')->all();
 
         $events_to_delete = DB::table('events')
             ->where('organization_id', $org->id)
+            ->whereNotIn('service_id', $service_ids)
             ->whereIn('active_at', $active_at_dates)
             ->get();
 

--- a/app-modules/event-importer/src/Console/Commands/ImportEventsCommand.php
+++ b/app-modules/event-importer/src/Console/Commands/ImportEventsCommand.php
@@ -2,7 +2,6 @@
 
 namespace HackGreenville\EventImporter\Console\Commands;
 
-use App\Models\Event;
 use App\Models\Org;
 use Glhd\ConveyorBelt\IteratesIdQuery;
 use HackGreenville\EventImporter\Data\EventData;
@@ -32,8 +31,8 @@ class ImportEventsCommand extends Command
             $min_cutoff = now()->subDays(config('event-import-handlers.max_days_in_past'));
             $max_cutoff = now()->addDays(config('event-import-handlers.max_days_in_future'));
 
-            Event::query()
-                ->where('organization_id', $org->id)
+            DB::table('events')
+                ->where('organization_id', '=', $org->id)
                 ->where('active_at', '>', $min_cutoff)
                 ->where('active_at', '<', $max_cutoff)
                 ->delete();

--- a/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
+++ b/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
@@ -69,9 +69,9 @@ class ExceptionStub extends AbstractEventHandler
 
 class ImportEventsCommandTest extends DatabaseTestCase
 {
-    public $meetup_rest = EventServices::MeetupRest->value;
-    public $meetup_graphql = EventServices::MeetupGraphql->value;
-    public $eventbrite = EventServices::EventBrite->value;
+    public const MEETUP_REST = 'meetup';
+    public const MEETUP_GRAPHQL = 'meetup_graphql';
+    public const EVENTBRITE = 'eventbrite';
 
     public const SERVICE_ID = '12345';
     public const ALT_SERVICE_ID = 'foobar';
@@ -84,7 +84,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_new_event_is_imported(): void
     {
-        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
+        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
 
         $this->runImportCommand();
 
@@ -94,7 +94,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_imported_event_updates_event_with_same_service_id(): void
     {
-        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
+        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
 
         $this->createEvent(0, self::SERVICE_ID);
 
@@ -107,19 +107,22 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_meetup_rest_org_at_same_time_different_service_id_is_deleted(): void
     {
-        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
+        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
 
         $this->createEvent(0, self::ALT_SERVICE_ID);
 
         $this->runImportCommand();
 
-        $result = $this->queryEvent(self::ALT_SERVICE_ID);
-        $this->assertNull($result);
+        $dupe_event = $this->queryEvent(self::ALT_SERVICE_ID);
+        $this->assertNull($dupe_event);
+
+        $new_event = $this->queryEvent(self::SERVICE_ID);
+        $this->assertNotNull($new_event);
     }
 
     public function test_event_for_meetup_graphql_org_at_same_time_different_service_id_is_deleted(): void
     {
-        $this->setServiceValues($this->meetup_graphql, self::SERVICE_ID);
+        $this->setServiceValues(self::MEETUP_GRAPHQL, self::SERVICE_ID);
 
         $this->createEvent(0, self::ALT_SERVICE_ID);
 
@@ -131,7 +134,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_org_at_different_time_different_service_id_is_not_deleted(): void
     {
-        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
+        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
 
         $this->createEvent(1, self::ALT_SERVICE_ID);
 
@@ -143,7 +146,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_non_meetup_at_same_time_different_service_id_is_not_deleted(): void
     {
-        $this->setServiceValues($this->eventbrite, self::SERVICE_ID);
+        $this->setServiceValues(self::EVENTBRITE, self::SERVICE_ID);
 
         $this->createEvent(1, self::ALT_SERVICE_ID);
 
@@ -155,7 +158,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_different_org_is_not_deleted(): void
     {
-        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
+        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
 
         $org = Org::factory()->create();
         $this->createEvent(0, self::ALT_SERVICE_ID, $org->id);
@@ -168,7 +171,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_import_on_exception_does_not_delete_records(): void
     {
-        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
+        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
 
         config()->set('event-import-handlers.handlers', [
             $this->getServiceName() => ExceptionStub::class,

--- a/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
+++ b/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
@@ -158,7 +158,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
         $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
 
         $org = Org::factory()->create();
-        $this->createEvent(1, self::ALT_SERVICE_ID, $org->id);
+        $this->createEvent(0, self::ALT_SERVICE_ID, $org->id);
 
         $this->runImportCommand();
 

--- a/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
+++ b/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace HackGreenville\EventImporter\Tests\Feature;
+
+use App\Enums\EventServices;
+use App\Models\Event;
+use App\Models\Org;
+use HackGreenville\EventImporter\Console\Commands\ImportEventsCommand;
+use HackGreenville\EventImporter\Data\EventData;
+use HackGreenville\EventImporter\Data\VenueData;
+use HackGreenville\EventImporter\Services\Concerns\AbstractEventHandler;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use Tests\DatabaseTestCase;
+
+class Stub extends AbstractEventHandler
+{
+    public static string $service = EventServices::EventBrite->value;
+    public static string $service_id = 'stub_id';
+
+    // Stub implementation for testing
+    protected function mapIntoEventData(array $data): EventData
+    {
+        return EventData::from([
+            'service' => self::$service,
+            'service_id' => self::$service_id,
+            'name' => 'Stub Event',
+            'description' => 'This is a stub event for testing.',
+            'url' => 'http://example.com/stub-event',
+            'starts_at' => Carbon::now()->addDays(1),
+            'ends_at' => Carbon::now()->addDays(2),
+            'timezone' => 'UTC',
+            'cancelled_at' => null,
+            'rsvp' => 0,
+            'venue' => null,
+        ]);
+    }
+
+    protected function mapIntoVenueData(array $data): ?VenueData
+    {
+        return null;
+    }
+
+    protected function eventResults(int $page): Collection
+    {
+        return collect([[]]); // return non-empty array to simulate events
+    }
+}
+
+class ImportEventsCommandTest extends DatabaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2020-01-15');
+
+        config()->set('event-import-handlers.max_days_in_past', 5);
+        config()->set('event-import-handlers.max_days_in_future', 5);
+        config()->set('event-import-handlers.handlers', [
+            Stub::$service => Stub::class,
+        ]);
+        config()->set('event-import-handlers.active_services', [
+            Stub::$service
+        ]);
+
+        Org::factory()->create([
+            'service' => Stub::$service,
+            'service_api_key' => '123456789',
+        ]);
+    }
+
+    public function test_new_event_is_imported(): void
+    {
+        $this->runImportCommand();
+
+        $result = $this->queryEvent(Stub::$service_id);
+        $this->assertNotNull($result);
+    }
+
+    public function test_old_event_outside_days_in_past_not_deleted(): void
+    {
+        $this->createEvent(-6, 'foobar');
+
+        $this->runImportCommand();
+
+        $result = $this->queryEvent('foobar');
+        $this->assertNotNull($result);
+    }
+
+    public function test_future_event_outside_days_in_future_not_deleted(): void
+    {
+        $this->createEvent(6, 'foobar');
+
+        $this->runImportCommand();
+
+        $result = $this->queryEvent('foobar');
+        $this->assertNotNull($result);
+    }
+
+    public function test_imported_event_with_service_id_is_updated(): void
+    {
+        $this->createEvent(0, Stub::$service_id);
+
+        $this->runImportCommand();
+
+        $result = $this->queryEvent(Stub::$service_id);
+        $this->assertNotNull($result);
+        $this->assertEquals('Stub Event', $result->event_name);
+    }
+
+    private function createEvent(int $daysToAdd, string $service_id): void
+    {
+        Event::factory()->create([
+            'organization_id' => 1,
+            'service' => Stub::$service,
+            'service_id' => $service_id,
+            'event_name' => 'Existing Event',
+            'active_at' => Carbon::now()->addDays($daysToAdd),
+        ]);
+    }
+
+    private function queryEvent(string $service_id): Event | null
+    {
+        return Event::query()->where('service_id', $service_id)->first();
+    }
+
+    private function runImportCommand(): void
+    {
+        $this->artisan(ImportEventsCommand::class);
+    }
+}

--- a/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
+++ b/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
@@ -50,7 +50,7 @@ class Stub extends AbstractEventHandler
 
 class ExceptionStub extends AbstractEventHandler
 {
-    public static string $service = EventServices::EventBrite->value;
+    public static string $service = 'eventbrite';
     public static string $service_id = 'stub_id';
 
     // Simulate an exception thrown during event data mapping

--- a/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
+++ b/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
@@ -2,7 +2,6 @@
 
 namespace HackGreenville\EventImporter\Tests\Feature;
 
-use App\Enums\EventServices;
 use App\Models\Event;
 use App\Models\Org;
 use Exception;

--- a/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
+++ b/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
@@ -16,7 +16,7 @@ use Tests\DatabaseTestCase;
 
 class Stub extends AbstractEventHandler
 {
-    public static string $service = EventServices::EventBrite->value;
+    public static string $service = 'eventbrite';
     public static string $service_id = 'stub_id';
 
     // Stub implementation for testing

--- a/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
+++ b/app-modules/event-importer/tests/Feature/ImportEventsCommandTest.php
@@ -69,9 +69,9 @@ class ExceptionStub extends AbstractEventHandler
 
 class ImportEventsCommandTest extends DatabaseTestCase
 {
-    public const MEETUP_REST = EventServices::MeetupRest->value;
-    public const MEETUP_GRAPHQL = EventServices::MeetupGraphql->value;
-    public const EVENTBRITE = EventServices::EventBrite->value;
+    public $meetup_rest = EventServices::MeetupRest->value;
+    public $meetup_graphql = EventServices::MeetupGraphql->value;
+    public $eventbrite = EventServices::EventBrite->value;
 
     public const SERVICE_ID = '12345';
     public const ALT_SERVICE_ID = 'foobar';
@@ -84,7 +84,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_new_event_is_imported(): void
     {
-        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
+        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
 
         $this->runImportCommand();
 
@@ -94,7 +94,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_imported_event_updates_event_with_same_service_id(): void
     {
-        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
+        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
 
         $this->createEvent(0, self::SERVICE_ID);
 
@@ -107,7 +107,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_meetup_rest_org_at_same_time_different_service_id_is_deleted(): void
     {
-        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
+        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
 
         $this->createEvent(0, self::ALT_SERVICE_ID);
 
@@ -119,7 +119,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_meetup_graphql_org_at_same_time_different_service_id_is_deleted(): void
     {
-        $this->setServiceValues(self::MEETUP_GRAPHQL, self::SERVICE_ID);
+        $this->setServiceValues($this->meetup_graphql, self::SERVICE_ID);
 
         $this->createEvent(0, self::ALT_SERVICE_ID);
 
@@ -131,7 +131,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_org_at_different_time_different_service_id_is_not_deleted(): void
     {
-        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
+        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
 
         $this->createEvent(1, self::ALT_SERVICE_ID);
 
@@ -143,7 +143,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_non_meetup_at_same_time_different_service_id_is_not_deleted(): void
     {
-        $this->setServiceValues(self::EVENTBRITE, self::SERVICE_ID);
+        $this->setServiceValues($this->eventbrite, self::SERVICE_ID);
 
         $this->createEvent(1, self::ALT_SERVICE_ID);
 
@@ -155,7 +155,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_for_different_org_is_not_deleted(): void
     {
-        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
+        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
 
         $org = Org::factory()->create();
         $this->createEvent(0, self::ALT_SERVICE_ID, $org->id);
@@ -168,7 +168,7 @@ class ImportEventsCommandTest extends DatabaseTestCase
 
     public function test_event_import_on_exception_does_not_delete_records(): void
     {
-        $this->setServiceValues(self::MEETUP_REST, self::SERVICE_ID);
+        $this->setServiceValues($this->meetup_rest, self::SERVICE_ID);
 
         config()->set('event-import-handlers.handlers', [
             $this->getServiceName() => ExceptionStub::class,


### PR DESCRIPTION
A current theory to the issue causing #411 is that updates to Meetup events, in particular recurring events, is causing a [duplicate Meetup event](https://theeventscalendar.com/support/forums/topic/modified-meetup-events-creating-duplicates/) to be created with a different service ID. 

While I haven't been able to repro this issue locally, I have seen in some of the API responses that only one of the duplicates appear in the GraphQL API response. This helps support the theory that updates are causing duplicates.

In this solution, I am looking to check and remove duplicates for `meetup` and `meetup_graphql` events only. I check on events within the org for the same timestamp and delete the existing DB records before inserting the new records.