### PR TITLE
Prevent import of events where the token id matches an existing event

### DIFF
--- a/app-modules/event-importer/src/Services/MeetupGraphqlHandler.php
+++ b/app-modules/event-importer/src/Services/MeetupGraphqlHandler.php
@@ -39,7 +39,7 @@ class MeetupGraphqlHandler extends AbstractEventHandler
             },
             'rsvp' => $event['going'],
             'service' => EventServices::MeetupGraphql,
-            'service_id' => $event['id'],
+            'service_id' => $event['token'] ?? $event['id'],
             'venue' => $this->mapIntoVenueData($data),
         ]);
 

--- a/app-modules/event-importer/tests/Feature/MeetupGraphqlTest.php
+++ b/app-modules/event-importer/tests/Feature/MeetupGraphqlTest.php
@@ -110,6 +110,7 @@ class MeetupGraphqlTest extends DatabaseTestCase
 
         $event = $this->queryEvent('pwdqjtygcpbkb');
 
+        $this->assertNotNull($event);
         $this->assertNull($event->venue);
     }
 
@@ -129,6 +130,25 @@ class MeetupGraphqlTest extends DatabaseTestCase
         $event = $this->queryEvent('pwdqjtygcqbhb');
 
         $this->assertNull($event);
+    }
+
+    public function test_duplicate_event_is_not_imported(): void
+    {
+        $this->runImportCommand();
+
+        Event::factory()->create([
+            'service' => EventServices::MeetupGraphql,
+            'service_id' => '306527183',
+            'updated_at' => now()->subDays(1),
+        ]);
+
+        $event_original = $this->queryEvent('306527183');
+        $this->assertNotNull($event_original);
+
+        $this->assertEquals(now(), $event_original->updated_at);
+
+        $event_duplicate = $this->queryEvent('mfuaiakmcxuzjsd');
+        $this->assertNull($event_duplicate);
     }
 
     public function test_config_validation_fails_with_missing_client_id(): void

--- a/app-modules/event-importer/tests/fixtures/meetup-graphql/example-group.json
+++ b/app-modules/event-importer/tests/fixtures/meetup-graphql/example-group.json
@@ -148,7 +148,6 @@
             "cursor": "MzAyMTkwMDU3OjE3MjI1NDk2MDAwMDA=",
             "node": {
               "id": "302190057",
-              "token": "302190057",
               "title": "DEF CON 864 Meeting",
               "eventUrl": "https://www.meetup.com/defcon864/events/302190057",
               "description": "Join us for the monthly DEF CON 864 group meeting online and in-person.\n\n* Online details are posted in our Discord.\n* Discord invite is on our website at dc864.org.\n\nAll meetings are free and open to the public.\n\nWe have a very open format, so join in and let us know what your interests are that you'd like to see from this group.\n\nWe leave an hour to going over member projects and interests. Have a Raspberry Pi project or build a custom drone? Bring it in and show us how you did it. Creating your own set of scripts for system reconnaissance? We'd love to see it.",
@@ -257,6 +256,32 @@
               "eventUrl": "https://www.meetup.com/defcon864/events/pwdqjtygcqbhb",
               "description": "Join us for the monthly DEF CON 864 group meeting online and in-person.\n\n* Online details are posted in our Discord.\n* Discord invite is on our website at dc864.org.\n\nAll meetings are free and open to the public.\n\nWe have a very open format, so join in and let us know what your interests are that you'd like to see from this group.\n\nWe leave an hour to going over member projects and interests. Have a Raspberry Pi project or build a custom drone? Bring it in and show us how you did it. Creating your own set of scripts for system reconnaissance? We'd love to see it.",
               "dateTime": "2020-01-20T18:00-05:00",
+              "eventType": "PHYSICAL",
+              "status": "published",
+              "going": 2,
+              "createdAt": null,
+              "venue": {
+                "id": "26458417",
+                "name": "1508 Pelham Rd",
+                "address": "1508 Pelham Rd",
+                "city": "Greenville",
+                "state": "SC",
+                "postalCode": "29615",
+                "country": "us",
+                "lat": 34.857014,
+                "lng": -82.29995
+              }
+            }
+          },
+          {
+            "cursor": "cHdkcWp0eWdjcWJoYjoxNzMzNDM5NjAwMDAy",
+            "node": {
+              "id": "mfuaiakmcxuzjsd",
+              "token": "306527183",
+              "title": "DEF CON 864 Meeting",
+              "eventUrl": "https://www.meetup.com/defcon864/events/mfuaiakmcxuzjsd",
+              "description": "Join us for the monthly DEF CON 864 group meeting online and in-person.\n\n* Online details are posted in our Discord.\n* Discord invite is on our website at dc864.org.\n\nAll meetings are free and open to the public.\n\nWe have a very open format, so join in and let us know what your interests are that you'd like to see from this group.\n\nWe leave an hour to going over member projects and interests. Have a Raspberry Pi project or build a custom drone? Bring it in and show us how you did it. Creating your own set of scripts for system reconnaissance? We'd love to see it.",
+              "dateTime": "2020-01-10T18:00-05:00",
               "eventType": "PHYSICAL",
               "status": "published",
               "going": 2,


### PR DESCRIPTION
Addresses #411 

After some investigation and discussion, we have identified that duplicate entries can be identified via the `token` attribute on the [event data](https://www.meetup.com/api/schema/#Event).

We added some logs to capture duplicate events as they came through, and the token values would match the id of the original event. I have reasonable confidence that this solution will reduce the occurrence of duplication in the future.