### PR TITLE
Docs: Add a note about the APIs being cached and therefore changes being delayed

### DIFF
--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -13,7 +13,7 @@ By default, results are returned in JSON format.
 
 ## Limitations and Gotchas
 * The Events API's responses are controlled by [server .env variables](/CONTRIBUTING.md#environment-variables) that may limit the data available to calling / consuming applications. Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the HackGreenville.com Events API endpoints referenced above.
-* The productive / live website is cached and changes may take up to 4 hours to show due to the cache.
+* The production / live website is cached and changes may take up to 4 hours to show due to the cache.
 * All timestamps are in UTC.  
 * The event description fields may include HTML markup.  This application does not sanitize those fields and it's unclear if the upstream source should be trusted, so sanitize any output to avoid malicious cross-site scripting (XSS).
 * Previously, an `Accept: application/json+ld` header could be sent to the API to fetch [Schema.org Event markup](https://schema.org/Event) in JSON+LD format. However, this feature is not implemented in the newest version.

--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -13,6 +13,7 @@ By default, results are returned in JSON format.
 
 ## Limitations and Gotchas
 * The Events API's responses are controlled by [server .env variables](/CONTRIBUTING.md#environment-variables) that may limit the data available to calling / consuming applications. Contact [HackGreenville Labs](https://hackgreenville.com/labs) with any questions about these limits for the HackGreenville.com Events API endpoints referenced above.
+* The productive / live website is cached and changes may take up to 4 hours to show due to the cache.
 * All timestamps are in UTC.  
 * The event description fields may include HTML markup.  This application does not sanitize those fields and it's unclear if the upstream source should be trusted, so sanitize any output to avoid malicious cross-site scripting (XSS).
 * Previously, an `Accept: application/json+ld` header could be sent to the API to fetch [Schema.org Event markup](https://schema.org/Event) in JSON+LD format. However, this feature is not implemented in the newest version.

--- a/ORGS_API.md
+++ b/ORGS_API.md
@@ -10,6 +10,6 @@ The _Organizations API_ can be used to build your own custom applications from t
   * For example, ID 1 is the tag for events related to [OpenWorks Coworking](https://joinopenworks.com).
 
 ## Contributor Notes
-* The productive / live website is cached and changes may take up to 4 hours to show due to the cache.
+* The production / live website is cached and changes may take up to 4 hours to show due to the cache.
 * For those looking to help develop the _Organizations API_, the code is located at _app-modules/api/src/Http/Controllers/OrgsApiV0Controller.php_.
 * When viewing the API's response JSON, it's best to use Firefox, or enable the "Pretty Print" option in your browser.

--- a/ORGS_API.md
+++ b/ORGS_API.md
@@ -10,5 +10,6 @@ The _Organizations API_ can be used to build your own custom applications from t
   * For example, ID 1 is the tag for events related to [OpenWorks Coworking](https://joinopenworks.com).
 
 ## Contributor Notes
+* The productive / live website is cached and changes may take up to 4 hours to show due to the cache.
 * For those looking to help develop the _Organizations API_, the code is located at _app-modules/api/src/Http/Controllers/OrgsApiV0Controller.php_.
 * When viewing the API's response JSON, it's best to use Firefox, or enable the "Pretty Print" option in your browser.


### PR DESCRIPTION
The production site is behind Cloudflare, so there's up to 4 hours of delay, as now noted in the API docs.