### PR TITLE
Add FullCalendar setting to height: auto

### DIFF
--- a/resources/views/calendar/index.blade.php
+++ b/resources/views/calendar/index.blade.php
@@ -19,6 +19,7 @@
             const calendarEl = document.getElementById('calendar');
 
             const calendar = new FullCalendar.Calendar(calendarEl, {
+                height: 'auto',
                 plugins: ['dayGrid', 'list'],
                 header: {
                     left: 'title',


### PR DESCRIPTION
I'm hoping this will make the double scroll bars go away in normal web browser and mobile.