### PR TITLE
Docs: Update Orgs and Events API Docs Due to API Explorer

### DIFF
--- a/EVENTS_API.md
+++ b/EVENTS_API.md
@@ -26,7 +26,7 @@ The code for the Events API is primarily located in _/app-modules/_
 
 * Controllers: _api/src/Http/Controllers/_
 * Resources: _api/src/Resources/_
-* Test fixtures: _api/tests/Feature/_
+* Tests: _api/tests/Feature/_
 
 ### Luma.com
 

--- a/ORGS_API.md
+++ b/ORGS_API.md
@@ -23,7 +23,7 @@ The code for the Organizations API is primarily located in _/app-modules/_
 
 * Controllers: _api/src/Http/Controllers/_
 * Resources: _api/src/Resources/_
-* Test fixtures: _api/tests/Feature/_
+* Tests: _api/tests/Feature/_
 
 ## Kudos to Past Contributors
 * Thanks to @allella for the initial development on Drupal


### PR DESCRIPTION
* Removed old documentation since the API explorer tool at /docs/api does all of what we had and then some.
* Focused on directing people to the API explorer and using the v1 API for projects.
* Tweaked various bullets to make it more readable and current.

The changes can be viewed at
https://github.com/allella/hackgreenville-com/blob/docs/api-changes/EVENTS_API.md
https://github.com/allella/hackgreenville-com/blob/docs/api-changes/ORGS_API.md