### PR TITLE
Dependabot: Set weekly, grouped updates and daily security updates limit notifications and merges

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,8 @@
+# security updates are handled separately via Github settings
+# when 'Dependabot security updates' is enabled under the repo's
+# Settings > Security > Advanced Security
 version: 2
 updates:
-  # ----------------------------------------------------
-  # Composer – Daily security updates
-  # ----------------------------------------------------
-  - package-ecosystem: composer
-    directory: "/"
-    schedule:
-      interval: daily
-    security-updates-only: true
-    versioning-strategy: lockfile-only
-
-  # ----------------------------------------------------
-  # npm – Daily security updates
-  # ----------------------------------------------------
-  - package-ecosystem: npm
-    directory: "/"
-    schedule:
-      interval: daily
-    security-updates-only: true
-    versioning-strategy: lockfile-only
-
   # ----------------------------------------------------
   # Composer – Weekly grouped non-security updates (Tuesday)
   # ----------------------------------------------------
@@ -28,13 +11,11 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    security-updates-only: false
     versioning-strategy: lockfile-only
     groups:
       composer-all:
         patterns:
           - "*"
-
   # ----------------------------------------------------
   # npm – Weekly grouped non-security updates (Tuesday)
   # ----------------------------------------------------
@@ -43,7 +24,6 @@ updates:
     schedule:
       interval: weekly
       day: tuesday
-    security-updates-only: false
     versioning-strategy: lockfile-only
     groups:
       npm-all:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,51 @@
 version: 2
 updates:
+  # ----------------------------------------------------
+  # Composer – Daily security updates
+  # ----------------------------------------------------
   - package-ecosystem: composer
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
+    security-updates-only: true
     versioning-strategy: lockfile-only
+
+  # ----------------------------------------------------
+  # npm – Daily security updates
+  # ----------------------------------------------------
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 1
+    security-updates-only: true
     versioning-strategy: lockfile-only
+
+  # ----------------------------------------------------
+  # Composer – Weekly grouped non-security updates (Tuesday)
+  # ----------------------------------------------------
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+    security-updates-only: false
+    versioning-strategy: lockfile-only
+    groups:
+      composer-all:
+        patterns:
+          - "*"
+
+  # ----------------------------------------------------
+  # npm – Weekly grouped non-security updates (Tuesday)
+  # ----------------------------------------------------
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: tuesday
+    security-updates-only: false
+    versioning-strategy: lockfile-only
+    groups:
+      npm-all:
+        patterns:
+          - "*"


### PR DESCRIPTION
This will allow security updates to continue on a daily basis.

Groups are enabled on the non-security updates to do one PR for any available _minor_ updates at once.  Since we are limiting things to minor version updates (via `versioning-strategy: lockfile-only`) I'm assuming this won't create any large or complicated to review minor package updates. If so, we can adjust course.

The _open-pull-requests-limit_ previously limited the number of PRs opened at once.  That could actually delay notifications if we didn't quickly close an earlier PR.  This limit has been removed since the "groups" should make for few, larger non-security PRs.  Plus, Dependabot can open multiple security PRs without a backlogged / queued up series that could create a new PR as soon as we just closed one, which seems like it creates more work and more CI/CD processing than if we are merging a number of PRs in bulk.
