### PR TITLE
Tweak the Slack Notifications for Join Slack and Contact Form

### DIFF
--- a/app/Notifications/ContactMessage.php
+++ b/app/Notifications/ContactMessage.php
@@ -27,12 +27,12 @@ class ContactMessage extends Notification implements ShouldQueue
     {
         return (new SlackMessage)
             ->success()
-            ->content('A new contact submission has been received')
+            ->content(':mailbox_with_mail: HG Website Contact Form Request :mailbox_with_mail:')
             ->attachment(function ($attachment) {
                 $attachment->title('Reply via email', url("mailto:{$this->contact}"))
                     ->fields([
                         'Name' => $this->name,
-                        'Contact' => $this->contact,
+                        'Email' => $this->contact,
                         'Message' => $this->message,
                     ]);
             });

--- a/app/Notifications/JoinMessage.php
+++ b/app/Notifications/JoinMessage.php
@@ -49,14 +49,14 @@ class JoinMessage extends Notification implements ShouldQueue
     {
         return (new SlackMessage)
             ->success()
-            ->content('A new sign-up submission has been received')
+            ->content(':traffic_light: Join HG Slack Request :traffic_light:')
             ->attachment(function ($attachment) {
                 $attachment
                     ->fields([
                         'Name' => $this->name,
-                        'Contact' => $this->contact,
+                        'Email to Invite' => $this->contact,
                         'Reason' => $this->reason,
-                        'Url' => $this->url,
+                        'URL' => $this->url,
                     ]);
             });
     }


### PR DESCRIPTION
This adds some icons and changes a few words so it should be easier to spot a general contact request vs a join request.

Closes #716 