### PR TITLE
Tweak/event page future events

### DIFF
--- a/app/Http/Controllers/CalendarFeedController.php
+++ b/app/Http/Controllers/CalendarFeedController.php
@@ -41,7 +41,7 @@ class CalendarFeedController extends Controller
     {
         $events = Event::query()
             ->with('organization', 'venue')
-            ->future()
+            ->ongoingAndFuture()
             ->oldest('active_at')
             ->when($request->validOrganizations()->isNotEmpty(), fn ($query) => $query->whereIn('organization_id', $request->validOrganizations()->pluck('id')))
             ->get()

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -8,7 +8,7 @@ class EventsController extends Controller
 {
     public function index()
     {
-        $months = Event::future()
+        $months = Event::ongoingAndFuture()
             ->published()
             ->with('organization', 'venue')
             ->orderBy('active_at')

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -9,7 +9,7 @@ class HomeController extends Controller
     public function index()
     {
         return view('index', [
-            'upcoming_events' => Event::future()
+            'upcoming_events' => Event::ongoingAndFuture()
                 ->published()
                 ->with('organization', 'venue')
                 ->oldest('active_at')

--- a/app/Http/Controllers/OrgsController.php
+++ b/app/Http/Controllers/OrgsController.php
@@ -27,7 +27,7 @@ class OrgsController extends Controller
                 'events' => function (Builder $query) {
                     $query
                         ->with('organization', 'venue')
-                        ->future()
+                        ->ongoingAndFuture()
                         ->published()
                         ->orderBy('active_at')
                         ->limit(25);

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -60,7 +60,7 @@ class Event extends BaseModel
 
     public function scopeFuture(Builder $query): void
     {
-//        $query->where('expire_at', '>=', now()_);
+        //        $query->where('expire_at', '>=', now()_);
         $query->where('expire_at', '>=', now()->startOfDay());
     }
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -60,6 +60,11 @@ class Event extends BaseModel
 
     public function scopeFuture(Builder $query): void
     {
+        $query->where('active_at', '>=', now());
+    }
+
+    public function scopeOngoingAndFuture(Builder $query): void
+    {
         $query->where('expire_at', '>=', now()->startOfDay());
     }
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -60,7 +60,6 @@ class Event extends BaseModel
 
     public function scopeFuture(Builder $query): void
     {
-//        $query->where('expire_at', '>=', now()_);
         $query->where('expire_at', '>=', now()->startOfDay());
     }
 

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -58,11 +58,9 @@ class Event extends BaseModel
             ->when( ! $startDate && ! $endDate, fn (Builder $q) => $q->where('active_at', '>=', now()->subDays(config('events-api.default_days'))));
     }
 
-    public function scopeFuture(Builder $query): void
-    {
-        $query->where('active_at', '>=', now());
-    }
-
+    // Include all future events AND current / ongoing events
+    // This avoids currently ongoing, or recently ended, events from
+    // disappearing until the day after they have ended
     public function scopeOngoingAndFuture(Builder $query): void
     {
         $query->where('expire_at', '>=', now()->startOfDay());

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -60,7 +60,8 @@ class Event extends BaseModel
 
     public function scopeFuture(Builder $query): void
     {
-        $query->where('active_at', '>=', now());
+//        $query->where('expire_at', '>=', now()_);
+        $query->where('expire_at', '>=', now()->startOfDay());
     }
 
     public function url(): string

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,4 +1,4 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 /* Migrate from tailwind.config.js theme.extend */
 @theme {
@@ -7,7 +7,9 @@
   --color-warning: #de9d35;
   --color-danger: #f44336;
 
-  --font-sans: 'Geist', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans-serif;
+  --font-sans: 'Geist', ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
+    sans-serif;
 
   --breakpoint-nav-break: 1220px;
 }
@@ -15,7 +17,7 @@
 /* Preserve v3 button cursor behavior */
 @layer base {
   button:not(:disabled),
-  [role="button"]:not(:disabled) {
+  [role='button']:not(:disabled) {
     cursor: pointer;
   }
 }

--- a/resources/js/labs-hero.js
+++ b/resources/js/labs-hero.js
@@ -5,7 +5,9 @@
  */
 export function initHeroCanvas(canvas) {
   const ctx = canvas.getContext('2d');
-  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const prefersReducedMotion = window.matchMedia(
+    '(prefers-reduced-motion: reduce)',
+  ).matches;
 
   const PARTICLE_COUNT = 60;
   const CONNECT_DISTANCE = 120;
@@ -55,7 +57,7 @@ export function initHeroCanvas(canvas) {
         const dy = p.y - mouse.y;
         const dist = Math.sqrt(dx * dx + dy * dy);
         if (dist < MOUSE_RADIUS && dist > 0) {
-          const force = (MOUSE_RADIUS - dist) / MOUSE_RADIUS * MOUSE_FORCE;
+          const force = ((MOUSE_RADIUS - dist) / MOUSE_RADIUS) * MOUSE_FORCE;
           p.vx += (dx / dist) * force;
           p.vy += (dy / dist) * force;
         }
@@ -91,7 +93,9 @@ export function initHeroCanvas(canvas) {
           ctx.beginPath();
           ctx.moveTo(p.x, p.y);
           ctx.lineTo(q.x, q.y);
-          ctx.strokeStyle = `rgba(255, 255, 255, ${0.15 * (1 - dist / CONNECT_DISTANCE)})`;
+          ctx.strokeStyle = `rgba(255, 255, 255, ${
+            0.15 * (1 - dist / CONNECT_DISTANCE)
+          })`;
           ctx.lineWidth = 0.5;
           ctx.stroke();
         }

--- a/tests/Feature/Http/Controllers/CalendarFeedTest.php
+++ b/tests/Feature/Http/Controllers/CalendarFeedTest.php
@@ -226,12 +226,11 @@ class CalendarFeedTest extends DatabaseTestCase
         $event = Event::factory()->create([
             'organization_id' => $organization->id,
             'cancelled_at' => null,
-            'active_at' => now()->subMinute(),
-            'expire_at' => now()->subMinute(),
+            'active_at' => now()->subWeek()->subMinute(),
+            'expire_at' => now()->subWeek(),
         ]);
 
         $first_response = $this->get(route('calendar-feed.show', ['orgs' => $organization->id]));
-
         preg_match('/UID:(.+)/', $first_response->getContent(), $first_match);
 
         $this->assertFalse(isset($first_match[1]));

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -20,14 +20,17 @@ class HomeControllerTest extends DatabaseTestCase
         Event::factory()->create([
             'event_name' => 'Event 2',
             'active_at' => '2020-01-01 19:00:00',
+            'expire_at' => '2020-01-02 21:00:00',
         ]);
         Event::factory()->create([
             'event_name' => 'Event 1',
             'active_at' => '2020-01-01 18:00:00',
+            'expire_at' => '2020-01-02 20:00:00',
         ]);
         Event::factory()->create([
             'event_name' => 'Event 3',
             'active_at' => '2020-01-02 12:00:00',
+            'expire_at' => '2020-01-02 14:00:00',
         ]);
 
         $response = $this->get(route('home'));
@@ -40,7 +43,8 @@ class HomeControllerTest extends DatabaseTestCase
     {
         Event::factory()->create([
             'event_name' => 'Event 1',
-            'active_at' => '2019-12-31 23:59:59',
+            'active_at' => '2019-12-31 22:00:00',
+            'expire_at' => '2019-12-31 23:00:00',
         ]);
 
         $response = $this->get(route('home'));

--- a/tests/Feature/Models/EventTest.php
+++ b/tests/Feature/Models/EventTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\Event;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class EventTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_scope_ongoing_and_future_includes_ongoing_events_expiring_right_now(): void
+    {
+        $this->freezeTime();
+        $event = Event::factory()->create(['expire_at' => now()]);
+
+        $this->assertTrue(Event::future()->get()->contains($event));
+    }
+
+    public function test_scope_ongoing_and_future_includes_events_that_expired_earlier_today(): void
+    {
+        $this->freezeTime();
+        $event = Event::factory()->create(['expire_at' => now()->startOfDay()]);
+
+        $this->assertTrue(Event::future()->get()->contains($event));
+    }
+
+    public function test_scope_ongoing_and_future_includes_multi_day_events_expiring_in_the_future(): void
+    {
+        $this->freezeTime();
+        $event = Event::factory()->create(['expire_at' => now()->addDays(3)]);
+
+        $this->assertTrue(Event::future()->get()->contains($event));
+    }
+
+    public function test_scope_ongoing_and_future_excludes_events_that_expired_yesterday(): void
+    {
+        $this->freezeTime();
+        $event = Event::factory()->create(['expire_at' => now()->subDay()->endOfDay()]);
+
+        $this->assertFalse(Event::future()->get()->contains($event));
+    }
+}

--- a/tests/Feature/Models/EventTest.php
+++ b/tests/Feature/Models/EventTest.php
@@ -15,7 +15,7 @@ class EventTest extends TestCase
         $this->freezeTime();
         $event = Event::factory()->create(['expire_at' => now()]);
 
-        $this->assertTrue(Event::future()->get()->contains($event));
+        $this->assertTrue(Event::ongoingAndFuture()->get()->contains($event));
     }
 
     public function test_scope_ongoing_and_future_includes_events_that_expired_earlier_today(): void
@@ -23,7 +23,7 @@ class EventTest extends TestCase
         $this->freezeTime();
         $event = Event::factory()->create(['expire_at' => now()->startOfDay()]);
 
-        $this->assertTrue(Event::future()->get()->contains($event));
+        $this->assertTrue(Event::ongoingAndFuture()->get()->contains($event));
     }
 
     public function test_scope_ongoing_and_future_includes_multi_day_events_expiring_in_the_future(): void
@@ -31,7 +31,7 @@ class EventTest extends TestCase
         $this->freezeTime();
         $event = Event::factory()->create(['expire_at' => now()->addDays(3)]);
 
-        $this->assertTrue(Event::future()->get()->contains($event));
+        $this->assertTrue(Event::ongoingAndFuture()->get()->contains($event));
     }
 
     public function test_scope_ongoing_and_future_excludes_events_that_expired_yesterday(): void
@@ -39,6 +39,6 @@ class EventTest extends TestCase
         $this->freezeTime();
         $event = Event::factory()->create(['expire_at' => now()->subDay()->endOfDay()]);
 
-        $this->assertFalse(Event::future()->get()->contains($event));
+        $this->assertFalse(Event::ongoingAndFuture()->get()->contains($event));
     }
 }

--- a/tests/Feature/NoIndexNonProductionTest.php
+++ b/tests/Feature/NoIndexNonProductionTest.php
@@ -8,7 +8,7 @@ class NoIndexNonProductionTest extends TestCase
 {
     public function test_robots_txt_disallows_all_in_non_production(): void
     {
-        $this->assertContains(app()->environment(), ['testing', 'local']);
+        $this->assertFalse(app()->isProduction());
         $response = $this->get('/robots.txt');
 
         $response->assertOk();

--- a/tests/Feature/NoIndexNonProductionTest.php
+++ b/tests/Feature/NoIndexNonProductionTest.php
@@ -8,8 +8,7 @@ class NoIndexNonProductionTest extends TestCase
 {
     public function test_robots_txt_disallows_all_in_non_production(): void
     {
-        $this->assertEquals('testing', app()->environment());
-
+        $this->assertContains(app()->environment(), ['testing', 'local']);
         $response = $this->get('/robots.txt');
 
         $response->assertOk();


### PR DESCRIPTION
Closes #725 

Changes the scope of future _scopeFuture()_ of events so the beginning of the current day is used in comparing to the event's expire_at, rather than the start time. 

This allows the day's current events, future events, and multi-day events that are still happening, to remain on the events page through the end of the last day of the event.

In the prior code, an event would disappear from /events immediate after it started. Though, in practice some may have hung around for hours longer due to whenever the CloudFlare caching expired the content.  

We also currently do not show a multi-day event on _/events_ iCal feed, and homepage beyond the first day, which seems like something we'd want to show through the last day it is happening.