### PR TITLE
Update .env.ci and .env.testing APP_ENV

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,8 +1,12 @@
+# Used for Github Actions test suite checks running `php artisan test --env=ci` against MySQL
+
 APP_NAME=HackGreenville
 APP_ENV=testing
 APP_KEY=base64:yKCXZDC0GPzDQ0GmXrG2RY4Q010/t494Auq/yCUXVpA=
 APP_DEBUG=true
 FORCE_SSL=false
+APP_URL=http://localhost
+LOG_CHANNEL=single
 
 DB_CONNECTION=mysql
 DB_HOST=127.0.0.1

--- a/.env.ci
+++ b/.env.ci
@@ -1,5 +1,5 @@
 APP_NAME=HackGreenville
-APP_ENV=local
+APP_ENV=testing
 APP_KEY=base64:yKCXZDC0GPzDQ0GmXrG2RY4Q010/t494Auq/yCUXVpA=
 APP_DEBUG=true
 FORCE_SSL=false

--- a/.env.testing
+++ b/.env.testing
@@ -1,11 +1,11 @@
+# Used for fast, local dev test suite checks running `php artisan test` against SQLite
+
 APP_NAME=HackGreenville
 APP_ENV=local
 APP_KEY=base64:yKCXZDC0GPzDQ0GmXrG2RY4Q010/t494Auq/yCUXVpA=
 APP_DEBUG=true
-APP_URL=http://localhost
-
 FORCE_SSL=false
-
+APP_URL=http://localhost
 LOG_CHANNEL=single
 
 DB_CONNECTION=sqlite

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,4 +55,4 @@ jobs:
         run: yarn build
 
       - name: run tests
-        run: php artisan test
+        run: php artisan test --env=ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -374,8 +374,8 @@ Telescope is a Laravel Debugging tool that allows you to see all the requests ma
 
 - The sample .env.example OR .env.docker is used as a template for new projects. A .env file must exist based on one of these files, based on how the app is running (Native or Docker)
 - The .env.ci and .env.testing are used for test suite checks for:
-  - _.env.ci_ | Github Actions running `php artisan test --env=ci` against MySQL in the test container.
-  - _.env.testing_ | fast, local running `php artisan test` against SQLite on dev.
+  - _.env.ci_ | Github Actions runs of `php artisan test --env=ci` against MySQL in the test container.
+  - _.env.testing_ | fast, local runs of `php artisan test` against SQLite on dev.
 - Be sure to clear the configuration cache after any changes to .env using `php artisan config:clear && php artisan config:cache`
 - Additional defaults may be as defined in _config/app.php_
 - Debugging can be enabled in development by setting `TELESCOPE_ENABLED=TRUE` in your local `.env`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,9 +373,9 @@ Telescope is a Laravel Debugging tool that allows you to see all the requests ma
 # Environment Variables
 
 - The sample .env.example OR .env.docker is used as a template for new projects. A .env file must exist based on one of these files, based on how the app is running (Native or Docker)
-- The .env.ci and .env.testing are used for test suite checks:
-  - _.env.ci_ | Github Actions running `php artisan test --env=ci` against MySQL.
-  - _.env.testing_ | fast, local dev test suite checks running `php artisan test` against SQLite.
+- The .env.ci and .env.testing are used for test suite checks for:
+  - _.env.ci_ | Github Actions running `php artisan test --env=ci` against MySQL in the test container.
+  - _.env.testing_ | fast, local running `php artisan test` against SQLite on dev.
 - Be sure to clear the configuration cache after any changes to .env using `php artisan config:clear && php artisan config:cache`
 - Additional defaults may be as defined in _config/app.php_
 - Debugging can be enabled in development by setting `TELESCOPE_ENABLED=TRUE` in your local `.env`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,8 +373,8 @@ Telescope is a Laravel Debugging tool that allows you to see all the requests ma
 # Environment Variables
 
 - The sample .env.example OR .env.docker is used as a template for new projects. A .env file must exist based on one of these files, based on how the app is running (Native or Docker)
-- The .env.ci and .env.testing are used for:
-  - _.env.ci_ | Github Actions test suite checks running `php artisan test --env=ci` against MySQL.
+- The .env.ci and .env.testing are used for test suite checks:
+  - _.env.ci_ | Github Actions running `php artisan test --env=ci` against MySQL.
   - _.env.testing_ | fast, local dev test suite checks running `php artisan test` against SQLite.
 - Be sure to clear the configuration cache after any changes to .env using `php artisan config:clear && php artisan config:cache`
 - Additional defaults may be as defined in _config/app.php_

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -373,7 +373,9 @@ Telescope is a Laravel Debugging tool that allows you to see all the requests ma
 # Environment Variables
 
 - The sample .env.example OR .env.docker is used as a template for new projects. A .env file must exist based on one of these files, based on how the app is running (Native or Docker)
-- The .env.ci and .env.testing are used for their respective tasks.
+- The .env.ci and .env.testing are used for:
+  - _.env.ci_ | Github Actions test suite checks running `php artisan test --env=ci` against MySQL.
+  - _.env.testing_ | fast, local dev test suite checks running `php artisan test` against SQLite.
 - Be sure to clear the configuration cache after any changes to .env using `php artisan config:clear && php artisan config:cache`
 - Additional defaults may be as defined in _config/app.php_
 - Debugging can be enabled in development by setting `TELESCOPE_ENABLED=TRUE` in your local `.env`

--- a/composer.lock
+++ b/composer.lock
@@ -8495,16 +8495,16 @@
         },
         {
             "name": "symfony/html-sanitizer",
-            "version": "v7.4.7",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/html-sanitizer.git",
-                "reference": "e4df2abd9391ce3263baa1aea9e993f6da74a3c7"
+                "reference": "761f6c49dfd103ee08b3cd09ece588b069e18ec9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/e4df2abd9391ce3263baa1aea9e993f6da74a3c7",
-                "reference": "e4df2abd9391ce3263baa1aea9e993f6da74a3c7",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/761f6c49dfd103ee08b3cd09ece588b069e18ec9",
+                "reference": "761f6c49dfd103ee08b3cd09ece588b069e18ec9",
                 "shasum": ""
             },
             "require": {
@@ -8545,7 +8545,7 @@
                 "sanitizer"
             ],
             "support": {
-                "source": "https://github.com/symfony/html-sanitizer/tree/v7.4.7"
+                "source": "https://github.com/symfony/html-sanitizer/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -8565,7 +8565,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T13:15:18+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/http-foundation",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,7 @@
         </include>
     </source>
     <php>
-        <env name="APP_ENV" value="testing"/>
+        <env name="APP_ENV" value="testing" force="true"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
          <env name="DB_CONNECTION" value="sqlite"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,7 +21,7 @@
         </include>
     </source>
     <php>
-        <env name="APP_ENV" value="testing" force="true"/>
+        <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
          <env name="DB_CONNECTION" value="sqlite"/>


### PR DESCRIPTION
Per conversation in #726 we had support for forcing PHPUnit to use testing.

[The Github action that runs our tests is copying .env.ci and that's set to 'local'](https://github.com/hackgvl/hackgreenville-com/pull/726#issuecomment-4531841112), which appears to preempt the phpunit.xml value.


