### PR TITLE
Add human design touches. Refactor: Replace custom HTML structures wi…

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -10,6 +10,8 @@
   --font-sans: 'Geist', ui-sans-serif, system-ui, -apple-system,
     BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans',
     sans-serif;
+  --font-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, monospace;
 
   --breakpoint-nav-break: 1220px;
 }

--- a/resources/css/third-party.css
+++ b/resources/css/third-party.css
@@ -8,6 +8,16 @@
     format('woff2');
 }
 
+/* Geist Mono Variable Font - by Vercel (https://vercel.com/font) */
+@font-face {
+  font-family: 'Geist Mono';
+  font-style: normal;
+  font-display: swap;
+  font-weight: 100 900;
+  src: url('/node_modules/geist/dist/fonts/geist-mono/GeistMono-Variable.woff2')
+    format('woff2');
+}
+
 /* Calendar specific styles */
 #calendar {
   min-height: 800px;

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,0 +1,25 @@
+@props([
+    'href' => null,
+    'variant' => 'primary',
+])
+
+@php
+    $classes = [
+        'inline-flex items-center justify-center gap-2 rounded-lg px-6 py-3 text-sm text-center no-underline transition-colors',
+        match ($variant) {
+            'ghost' => 'bg-white/10 backdrop-blur text-white font-semibold border border-white/20 hover:bg-white/20',
+            'outline' => 'border border-gray-200 text-gray-800 font-medium hover:border-gray-300 hover:bg-gray-50',
+            default => 'bg-success text-white font-semibold hover:bg-green-600',
+        },
+    ];
+@endphp
+
+@if ($href)
+    <a href="{{ $href }}" {{ $attributes->class($classes) }}>
+        {{ $slot }}
+    </a>
+@else
+    <button {{ $attributes->class($classes) }}>
+        {{ $slot }}
+    </button>
+@endif

--- a/resources/views/components/cta.blade.php
+++ b/resources/views/components/cta.blade.php
@@ -1,0 +1,16 @@
+@props(['title'])
+
+<div {{ $attributes->class('flex flex-col sm:flex-row sm:items-center sm:justify-between gap-6') }}>
+    <div class="max-w-xl">
+        <div class="w-9 h-1 rounded-full bg-success mb-4" aria-hidden="true"></div>
+        <h2 class="text-2xl font-bold tracking-tight text-primary mb-2">{{ $title }}</h2>
+        @if ($slot->isNotEmpty())
+            <p class="text-base text-gray-600">{{ $slot }}</p>
+        @endif
+    </div>
+    @isset($actions)
+        <div class="flex flex-col sm:flex-row gap-3 shrink-0">
+            {{ $actions }}
+        </div>
+    @endisset
+</div>

--- a/resources/views/components/hero.blade.php
+++ b/resources/views/components/hero.blade.php
@@ -1,0 +1,42 @@
+@props([
+    'mode' => null,
+    'image' => null,
+    'eyebrow' => null,
+    'canvasId' => 'hero-canvas',
+])
+
+@php
+    // Background mode: 'image', 'interactive', or 'plain'. Defaults to
+    // 'image' when an image is given, otherwise 'plain'.
+    $mode = $mode ?? ($image ? 'image' : 'plain');
+@endphp
+
+<div {{ $attributes->class('w-full text-white bg-primary relative overflow-hidden min-h-[28rem] sm:min-h-[32rem] flex items-center') }}>
+    @if ($mode === 'image' && $image)
+        <img src="{{ $image }}" alt="" class="absolute inset-0 w-full h-full object-cover object-center scale-105" aria-hidden="true"/>
+        <div class="absolute inset-0 bg-linear-to-r from-primary/95 via-primary/65 to-primary/35 z-2"></div>
+    @elseif ($mode === 'interactive')
+        <canvas id="{{ $canvasId }}" class="absolute inset-0 w-full h-full pointer-events-none" aria-hidden="true"></canvas>
+    @endif
+    {{ $media ?? '' }}
+    <div class="max-w-6xl mx-auto w-full relative z-10 py-16 sm:py-20 px-6 sm:px-8">
+        <div class="max-w-2xl">
+            @if ($eyebrow)
+                <p class="font-mono text-xs sm:text-sm tracking-[0.18em] uppercase text-green-300 mb-4 sm:mb-6">{{ $eyebrow }}</p>
+            @endif
+            <h1 class="text-4xl sm:text-5xl md:text-6xl font-extrabold tracking-tight text-white leading-tight">
+                {{ $slot }}
+            </h1>
+            @isset($subtitle)
+                <p class="text-lg sm:text-xl text-gray-300 mt-5 sm:mt-6 max-w-lg">
+                    {{ $subtitle }}
+                </p>
+            @endisset
+            @isset($actions)
+                <div class="flex flex-col sm:flex-row gap-3 mt-8 sm:mt-10">
+                    {{ $actions }}
+                </div>
+            @endisset
+        </div>
+    </div>
+</div>

--- a/resources/views/components/nav-dropdown-link.blade.php
+++ b/resources/views/components/nav-dropdown-link.blade.php
@@ -1,0 +1,7 @@
+@props(['route'])
+
+<li>
+    <a href="{{ route($route) }}" {{ $attributes->class('block px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-50 hover:text-primary no-underline transition-colors') }}>
+        {{ $slot }}
+    </a>
+</li>

--- a/resources/views/components/nav-dropdown.blade.php
+++ b/resources/views/components/nav-dropdown.blade.php
@@ -1,0 +1,36 @@
+@props([
+    'label',
+    'href' => null,
+    'align' => 'left',
+    'active' => false,
+])
+
+@php
+    $triggerClasses = [
+        'flex items-center gap-1 py-2 px-3 text-sm font-medium no-underline rounded-lg transition-colors',
+        $active ? 'text-white bg-white/10' : 'text-white/70 hover:text-white hover:bg-white/5',
+    ];
+@endphp
+
+<li class="hidden nav-break:block relative group">
+    @if ($href)
+        <a href="{{ $href }}" aria-haspopup="true" @class($triggerClasses)>
+            {{ $label }}
+            <x-lucide-chevron-down aria-hidden="true" class="size-3.5 transition-transform group-hover:rotate-180"/>
+        </a>
+    @else
+        <button aria-haspopup="true" @class($triggerClasses)>
+            {{ $label }}
+            <x-lucide-chevron-down aria-hidden="true" class="size-3.5 transition-transform group-hover:rotate-180"/>
+        </button>
+    @endif
+    <div @class([
+        'invisible group-hover:visible group-focus-within:visible opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-all duration-150 absolute top-full pt-2 z-50',
+        'right-0' => $align === 'right',
+        'left-0' => $align !== 'right',
+    ])>
+        <ul role="list" class="bg-white rounded-xl shadow-lg ring-1 ring-black/5 p-1 min-w-40 list-none pl-0 mb-0">
+            {{ $slot }}
+        </ul>
+    </div>
+</li>

--- a/resources/views/components/nav-link.blade.php
+++ b/resources/views/components/nav-link.blade.php
@@ -2,7 +2,7 @@
 
 <li>
     <a href="{{ route($route) }}"
-       class="block py-3 nav-break:py-2 px-4 nav-break:px-2 text-sm font-medium no-underline transition-colors text-center nav-break:text-left {{ Route::is($route) ? 'text-white font-semibold' : 'text-white/70 hover:text-white' }} {{ $class }}">
+       class="block py-2.5 nav-break:py-2 px-3 text-base nav-break:text-sm font-medium no-underline rounded-lg transition-colors {{ Route::is($route) ? 'text-white bg-white/10' : 'text-white/70 hover:text-white hover:bg-white/5' }} {{ $class }}">
         {{ $slot }}
     </a>
 </li>

--- a/resources/views/components/section-heading.blade.php
+++ b/resources/views/components/section-heading.blade.php
@@ -1,0 +1,20 @@
+@props(['level' => 2, 'align' => 'left'])
+
+<div {{ $attributes->class([
+    'text-center' => $align === 'center',
+    'flex flex-wrap items-end justify-between gap-4' => isset($actions),
+]) }}>
+    <div>
+        <div @class(['w-9 h-1 rounded-full bg-success mb-4', 'mx-auto' => $align === 'center']) aria-hidden="true"></div>
+        <h{{ $level }} @class([
+            'font-bold tracking-tight text-primary',
+            'text-3xl' => $level == 1,
+            'text-2xl sm:text-3xl' => $level != 1,
+        ])>{{ $slot }}</h{{ $level }}>
+    </div>
+    @isset($actions)
+        <div class="shrink-0 pb-1">
+            {{ $actions }}
+        </div>
+    @endisset
+</div>

--- a/resources/views/events/_item.blade.php
+++ b/resources/views/events/_item.blade.php
@@ -1,20 +1,30 @@
 <?php /** @var App\Models\Event $event */ ?>
 
 <div class="group/row px-4 sm:px-6 py-3 sm:py-4 hover:bg-gray-50/80 transition-colors">
-	<div class="flex items-start gap-3 md:grid md:grid-cols-12 md:gap-4 md:items-center">
+	<div class="flex items-start gap-3 md:items-center md:gap-4">
 		{{-- Date: desktop --}}
-		<div class="hidden md:block md:col-span-3">
-			<div class="font-semibold text-sm text-gray-700">
-				{{ $event->active_at->format('M jS Y') }}
+		<div class="hidden md:flex items-center gap-3 w-40 shrink-0">
+			<div class="w-12 shrink-0 rounded-lg border border-gray-950/10 overflow-hidden text-center bg-white">
+				<div class="bg-success/10 font-mono text-[0.6875rem] font-medium uppercase tracking-wide text-success py-0.5">
+					{{ $event->active_at->format('M') }}
+				</div>
+				<div class="text-lg font-semibold text-primary tabular-nums py-0.5">
+					{{ $event->active_at->format('j') }}
+				</div>
 			</div>
-			<div class="text-xs text-gray-500 mt-0.5">
-				{{ $event->active_at->format('l') }} • {{ $event->active_at->format('g:i A') }}
+			<div class="min-w-0">
+				<div class="text-xs font-medium text-gray-700">
+					{{ $event->active_at->format('l') }}
+				</div>
+				<div class="text-xs text-gray-500 mt-0.5">
+					{{ $event->active_at->format('g:i A') }}
+				</div>
 			</div>
 		</div>
 
 		{{-- Event info --}}
-		<div class="flex-1 min-w-0 md:col-span-7">
-			<a href="{{ $event->url() }}" rel="noopener" class="text-gray-700 hover:text-primary text-sm font-medium no-underline transition-colors">
+		<div class="flex-1 min-w-0">
+			<a href="{{ $event->url() }}" rel="noopener" class="text-primary hover:text-success text-sm font-medium no-underline transition-colors">
 				@if($event->cancelled_at)
 					<span class="text-danger font-semibold">[CANCELLED]</span>
 				@endif
@@ -22,29 +32,29 @@
 			</a>
 			<div class="text-xs text-gray-500 mt-0.5">
 				<a href="{{ route('orgs.show', $event->organization) }}" class="text-gray-500 hover:text-gray-700 no-underline transition-colors">
-					{{ $event->group_name }}
+					<span class="inline-block w-1.5 h-1.5 rounded-full bg-success align-middle mr-1.5" aria-hidden="true"></span>{{ $event->group_name }}
 				</a>
 			</div>
 			{{-- Date: mobile --}}
-			<div class="text-xs text-gray-500 mt-0.5 md:hidden">
-				{{ $event->active_at->format('M j') }} • {{ $event->active_at->format('g:i A') }}
+			<div class="font-mono text-[0.6875rem] tracking-wide text-success mt-0.5 md:hidden">
+				{{ $event->active_at->format('D, M j, Y') }} • {{ $event->active_at->format('g:i A') }}
 			</div>
 		</div>
 
 		{{-- Actions --}}
-		<div class="shrink-0 md:col-span-2 flex items-center justify-end gap-2">
+		<div class="shrink-0 flex items-center gap-2">
 			@if(!$event->cancelled_at)
 				<a href="{{ $event->toGoogleCalendarUrl() }}"
 				   rel="noopener"
-				   class="text-gray-200 hover:text-primary transition-colors md:opacity-0 md:group-hover/row:opacity-100"
+				   class="text-gray-300 hover:text-primary transition-colors md:opacity-0 md:group-hover/row:opacity-100"
 				   aria-label="Add {{ $event->event_name }} to Google Calendar">
 					<x-lucide-calendar-plus aria-hidden="true" class="w-4 h-4"/>
 				</a>
 				<a href="{{ $event->url() }}"
 				   rel="noopener"
-				   class="text-gray-200 hover:text-primary transition-colors"
+				   class="text-gray-300 hover:text-primary transition-colors"
 				   aria-label="View {{ $event->event_name }}">
-					<x-lucide-arrow-up-right aria-hidden="true" class="w-4 h-4"/>
+					<x-lucide-chevron-right aria-hidden="true" class="w-5 h-5"/>
 				</a>
 			@else
 				<span class="text-xs text-gray-300 font-medium">Cancelled</span>

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -45,7 +45,7 @@
 
         {{-- Header --}}
         <div class="mb-10">
-            <h1 class="text-3xl font-bold">Upcoming Events</h1>
+            <x-section-heading :level="1">Upcoming Events</x-section-heading>
             <p class="text-gray-500 mt-1 text-sm">
                 Aggregated from meetup groups, conferences, and community organizations across the Greenville, SC area
             </p>
@@ -73,11 +73,11 @@
         </div>
 
         {{-- Events list --}}
-        <div class="bg-white rounded-lg border border-gray-200 overflow-hidden">
+        <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
             @foreach($months as $month => $events)
                 <div class="events" data-date="{{ $month }}">
                     <div class="flex items-center gap-3 px-4 sm:px-6 py-3 bg-gray-50/80 border-b border-gray-200">
-                        <h2 class="text-xs font-bold text-gray-500 uppercase tracking-widest whitespace-nowrap">{{ $month }}</h2>
+                        <h2 class="font-mono text-xs font-bold text-success uppercase tracking-widest whitespace-nowrap">{{ $month }}</h2>
                         <div class="h-px bg-gray-200 flex-1"></div>
                         <span class="text-xs text-gray-300 font-medium tabular-nums">{{ $events->count() }}</span>
                     </div>

--- a/resources/views/hg-nights/index.blade.php
+++ b/resources/views/hg-nights/index.blade.php
@@ -5,31 +5,22 @@
 
 @section('content')
 	{{-- Hero --}}
-	<div class="relative bg-gray-900 text-white overflow-hidden min-h-[24rem] sm:min-h-[28rem] flex items-center">
-		<img src="{{ asset('img/hg-nights-sm.jpg') }}" alt="" class="absolute inset-0 w-full h-full object-cover object-center scale-105" aria-hidden="true" loading="eager"/>
-		<div class="absolute inset-0 bg-gradient-to-r from-gray-900/90 via-gray-900/70 to-gray-900/40 z-[2]"></div>
-		<div class="max-w-6xl mx-auto w-full px-4 sm:px-6 py-16 sm:py-20 relative z-10">
-			<div class="max-w-2xl">
-				<p class="text-sm font-medium tracking-widest uppercase text-green-400 mb-4">Quarterly Community Event</p>
-				<h1 class="text-3xl sm:text-4xl md:text-5xl font-bold leading-tight mb-4">HackGreenville Nights</h1>
-				<p class="text-lg text-gray-300 leading-relaxed max-w-lg mb-8">
-					A gathering of Greenville's tech, hacker, tinkerer, maker, and DIY community. Great food, short talks, and good people.
-				</p>
-				<div class="flex flex-col sm:flex-row gap-3">
-					<a href="https://www.meetup.com/hack-greenville/"
-					   rel="noopener" target="_blank"
-					   class="inline-block bg-success text-white px-6 py-3 rounded-lg text-sm font-semibold no-underline hover:bg-green-600 transition-colors">
-						Join our Meetup Group
-					</a>
-					<a href="https://forms.gle/oz4vDwrwG9c4h5Bo6"
-					   rel="nofollow noopener" target="_blank"
-					   class="inline-block bg-white/10 backdrop-blur text-white px-6 py-3 rounded-lg text-sm font-semibold no-underline hover:bg-white/20 transition-colors border border-white/20">
-						Submit a Talk
-					</a>
-				</div>
-			</div>
-		</div>
-	</div>
+	<x-hero :image="asset('img/hg-nights-sm.jpg')" eyebrow="Quarterly Community Event">
+		HackGreenville Nights
+
+		<x-slot:subtitle>
+			A gathering of Greenville's tech, hacker, tinkerer, maker, and DIY community. Great food, short talks, and good people.
+		</x-slot:subtitle>
+
+		<x-slot:actions>
+			<x-button href="https://www.meetup.com/hack-greenville/" rel="noopener" target="_blank">
+				Join our Meetup Group
+			</x-button>
+			<x-button href="https://forms.gle/oz4vDwrwG9c4h5Bo6" rel="nofollow noopener" target="_blank" variant="ghost">
+				Submit a Talk
+			</x-button>
+		</x-slot:actions>
+	</x-hero>
 
 	{{-- Submit a Talk + Get Involved --}}
 	<div class="max-w-6xl mx-auto px-4 py-14 sm:py-16">
@@ -165,19 +156,17 @@
 
 	{{-- CTA --}}
 	<div class="max-w-6xl mx-auto px-4 py-14 sm:py-16">
-		<div class="flex flex-col sm:flex-row items-center justify-between gap-6">
-			<div>
-				<h2 class="text-xl font-semibold mb-1">Want to sponsor or speak?</h2>
-				<p class="text-gray-600 text-sm">Reach out via the contact form or hop into our Slack.</p>
-			</div>
-			<div class="flex items-center gap-3">
-				<a href="{{ route('contact') }}" class="inline-block border border-gray-200 text-gray-800 px-6 py-3 rounded-lg text-sm font-semibold no-underline hover:border-gray-300 hover:bg-gray-50 transition-colors whitespace-nowrap">
+		<x-cta title="Want to sponsor or speak?">
+			Reach out via the contact form or hop into our Slack.
+
+			<x-slot:actions>
+				<x-button href="{{ route('contact') }}" variant="outline" class="whitespace-nowrap">
 					Contact Us
-				</a>
-				<a href="{{ route('join-slack') }}" class="inline-block bg-success text-white px-6 py-3 rounded-lg text-sm font-semibold no-underline hover:bg-green-600 transition-colors whitespace-nowrap">
+				</x-button>
+				<x-button href="{{ route('join-slack') }}" class="whitespace-nowrap">
 					Join Slack
-				</a>
-			</div>
-		</div>
+				</x-button>
+			</x-slot:actions>
+		</x-cta>
 	</div>
 @endsection

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -6,31 +6,20 @@
 @section('content')
     <div id="homepage" class="overflow-x-hidden">
         {{-- Hero --}}
-        <div id="homepage-jumbotron" class="w-full text-white bg-gray-900 relative overflow-hidden min-h-[28rem] sm:min-h-[32rem] flex items-center">
-            <img src="{{ asset('img/hackgreenville-banner.jpg') }}" alt="" class="absolute inset-0 w-full h-full object-cover object-center scale-105" aria-hidden="true"/>
-            <div class="absolute inset-0 bg-gradient-to-r from-gray-900/85 via-gray-900/60 to-gray-900/40 z-[2]"></div>
-            <div class="max-w-6xl mx-auto w-full px-6 sm:px-8 py-16 sm:py-24 relative z-10">
-                <div class="max-w-2xl">
-                    <p class="text-sm sm:text-base font-medium tracking-widest uppercase text-success mb-4 sm:mb-6">Greenville, SC Tech Community</p>
-                    <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold text-white leading-tight">
-                        Build Stuff.<br class="hidden sm:block"/>
-                        Meet People.<br class="hidden sm:block"/>
-                        Do Cool Things.
-                    </h1>
-                    <p class="text-lg sm:text-xl text-gray-300 mt-5 sm:mt-6 max-w-lg">
-                        Join hundreds of local hackers, makers, and tinkerers sharing meetups, talks, and projects.
-                    </p>
-                    <div class="flex flex-col sm:flex-row gap-3 mt-8 sm:mt-10">
-                        <a class="inline-block bg-success text-white px-7 py-3.5 rounded-lg text-base font-semibold no-underline hover:bg-green-600 transition-colors" href="/join-slack">
-                            Join Our Slack
-                        </a>
-                        <a class="inline-block bg-white/10 backdrop-blur text-white px-7 py-3.5 rounded-lg text-base font-semibold no-underline hover:bg-white/20 transition-colors border border-white/20" href="{{ route('events.index') }}">
-                            Browse Events
-                        </a>
-                    </div>
-                </div>
-            </div>
-        </div>
+        <x-hero id="homepage-jumbotron" :image="asset('img/hackgreenville-banner.jpg')" eyebrow="Greenville, SC Tech Community">
+            Build Stuff.<br class="hidden sm:block"/>
+            Meet People.<br class="hidden sm:block"/>
+            Do Cool Things.
+
+            <x-slot:subtitle>
+                Join hundreds of local hackers, makers, and tinkerers sharing meetups, talks, and projects.
+            </x-slot:subtitle>
+
+            <x-slot:actions>
+                <x-button href="/join-slack">Join Our Slack</x-button>
+                <x-button href="{{ route('events.index') }}" variant="ghost">Browse Events</x-button>
+            </x-slot:actions>
+        </x-hero>
 
         {{-- About + Image --}}
         <div class="py-16 sm:py-20">
@@ -40,7 +29,7 @@
                         <img src="{{ url('img/meetup.jpeg') }}" alt="HackGreenville community meetup" class="max-w-full h-auto rounded-lg shadow-md" loading="lazy">
                     </div>
                     <div>
-                        <h2 class="text-2xl sm:text-3xl font-light mb-4">What is HackGreenville?</h2>
+                        <x-section-heading class="mb-4">What is HackGreenville?</x-section-heading>
                         <p class="text-base text-gray-700 leading-relaxed mb-3">
                             HackGreenville is a community of "hackers" in and around Greenville, SC. We exist to foster personal growth through sharing and promoting local tech opportunities.
                         </p>
@@ -56,24 +45,24 @@
         {{-- Upcoming Events --}}
         <div class="bg-gray-50 py-16 sm:py-20">
             <div class="max-w-6xl mx-auto px-4">
-                <h2 class="text-center text-2xl sm:text-3xl font-light mb-8">
+                <x-section-heading class="mb-8">
                     Upcoming Events
-                </h2>
-                @if ($upcoming_events->isEmpty())
-                    <p class="text-center text-gray-500">
-                        <strong class="font-bold">No</strong> events to display.
-                    </p>
-                @else
-                    <div class="bg-white rounded-lg shadow-xs overflow-hidden divide-y divide-gray-200">
-                        @foreach ($upcoming_events as $event)
-                            @include('events._item', ['event' => $event])
-                        @endforeach
-                    </div>
-                    <div class="text-center mt-6">
-                        <a href="{{ route('events.index') }}" class="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:text-blue-700 no-underline transition-colors">
+                    <x-slot:actions>
+                        <a href="{{ route('events.index') }}" class="inline-flex items-center gap-1.5 text-sm font-medium text-success hover:text-green-700 no-underline transition-colors">
                             View all events
                             <x-lucide-arrow-right aria-hidden="true" class="w-3.5 h-3.5"/>
                         </a>
+                    </x-slot:actions>
+                </x-section-heading>
+                @if ($upcoming_events->isEmpty())
+                    <p class="text-gray-500">
+                        <strong class="font-bold">No</strong> events to display.
+                    </p>
+                @else
+                    <div class="bg-white rounded-xl border border-gray-200 shadow-xs overflow-hidden divide-y divide-gray-100">
+                        @foreach ($upcoming_events as $event)
+                            @include('events._item', ['event' => $event])
+                        @endforeach
                     </div>
                 @endif
             </div>
@@ -81,24 +70,21 @@
 
         {{-- Get Involved --}}
         <div class="py-16 sm:py-20">
-            <div class="max-w-3xl mx-auto px-4 text-center">
-                <h2 class="text-2xl sm:text-3xl font-light mb-3">Get Involved</h2>
-                <p class="text-base text-gray-600 mb-8 max-w-xl mx-auto">
+            <div class="max-w-6xl mx-auto px-4">
+                <x-cta title="Get Involved">
                     HackGreenville is open source and community-driven. Contribute code, suggest features, or help improve the platform.
-                </p>
-                <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
-                    <a href="https://github.com/hackgvl/hackgreenville-com"
-                       rel="noopener"
-                       class="inline-flex items-center gap-2 px-6 py-3 rounded-lg border border-gray-200 text-gray-800 hover:border-gray-300 hover:bg-gray-50 transition-colors no-underline text-sm font-medium">
-                        <x-lucide-github aria-hidden="true" class="w-5 h-5"/>
-                        View on GitHub
-                    </a>
-                    <a href="{{ route('contribute') }}"
-                       class="inline-flex items-center gap-2 px-6 py-3 rounded-lg border border-gray-200 text-gray-800 hover:border-gray-300 hover:bg-gray-50 transition-colors no-underline text-sm font-medium">
-                        <x-lucide-handshake aria-hidden="true" class="w-5 h-5"/>
-                        Volunteer &amp; Sponsor
-                    </a>
-                </div>
+
+                    <x-slot:actions>
+                        <x-button href="https://github.com/hackgvl/hackgreenville-com" rel="noopener" variant="outline">
+                            <x-lucide-github aria-hidden="true" class="w-5 h-5"/>
+                            View on GitHub
+                        </x-button>
+                        <x-button href="{{ route('contribute') }}" variant="outline">
+                            <x-lucide-handshake aria-hidden="true" class="w-5 h-5"/>
+                            Volunteer &amp; Sponsor
+                        </x-button>
+                    </x-slot:actions>
+                </x-cta>
             </div>
         </div>
     </div>

--- a/resources/views/labs/index.blade.php
+++ b/resources/views/labs/index.blade.php
@@ -5,18 +5,13 @@
 
 @section('content')
 	{{-- Hero --}}
-	<div class="bg-primary text-white relative overflow-hidden" id="labs-hero">
-		<canvas id="labs-hero-canvas" class="absolute inset-0 w-full h-full pointer-events-none" aria-hidden="true"></canvas>
-		<div class="max-w-6xl mx-auto px-4 py-16 sm:py-20 relative">
-			<div class="max-w-2xl">
-				<p class="text-sm font-medium tracking-widest uppercase text-green-300 mb-4">Open Source</p>
-				<h1 class="text-3xl sm:text-4xl md:text-5xl font-bold leading-tight mb-4">HackGreenville Labs</h1>
-				<p class="text-lg text-blue-100 leading-relaxed max-w-lg">
-					We build and maintain open source tools and public APIs that power the local tech community. Everything we make is free to use and open to contributors.
-				</p>
-			</div>
-		</div>
-	</div>
+	<x-hero id="labs-hero" mode="interactive" canvas-id="labs-hero-canvas" eyebrow="Open Source">
+		HackGreenville Labs
+
+		<x-slot:subtitle>
+			We build and maintain open source tools and public APIs that power the local tech community. Everything we make is free to use and open to contributors.
+		</x-slot:subtitle>
+	</x-hero>
 
 	{{-- Projects --}}
 	<div class="max-w-6xl mx-auto px-4 py-16 sm:py-20">
@@ -102,15 +97,15 @@
 				</div>
 			@endif
 
-			<div class="flex flex-col sm:flex-row items-center justify-between gap-6 @if($contributors->isNotEmpty()) pt-8 border-t border-gray-200 @endif">
-				<div>
-					<h2 class="text-xl font-semibold mb-1">Want to contribute?</h2>
-					<p class="text-gray-600 text-sm">Join our Slack and hop into <a href="https://hackgreenville.slack.com/channels/hg-labs" target="_blank" rel="noopener" class="font-medium text-gray-900 underline decoration-success/40 hover:decoration-success transition-colors">#hg-labs</a> to get started.</p>
-				</div>
-				<a href="{{ route('join-slack') }}" class="inline-block bg-success text-white px-6 py-3 rounded-lg text-sm font-semibold no-underline hover:bg-green-600 transition-colors whitespace-nowrap">
-					Join Slack
-				</a>
-			</div>
+			<x-cta title="Want to contribute?" :class="$contributors->isNotEmpty() ? 'pt-8 border-t border-gray-200' : ''">
+				Join our Slack and hop into <a href="https://hackgreenville.slack.com/channels/hg-labs" target="_blank" rel="noopener" class="font-medium text-gray-900 underline decoration-success/40 hover:decoration-success transition-colors">#hg-labs</a> to get started.
+
+				<x-slot:actions>
+					<x-button href="{{ route('join-slack') }}" class="whitespace-nowrap">
+						Join Slack
+					</x-button>
+				</x-slot:actions>
+			</x-cta>
 		</div>
 	</div>
 @endsection

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -89,7 +89,7 @@
 
     @yield('head')
 </head>
-<body>
+<body class="bg-white">
 <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-0 focus:left-0 focus:z-[9999] focus:px-6 focus:py-3 focus:bg-gray-900 focus:text-white focus:font-semibold focus:no-underline">Skip to main content</a>
 
 <div id="app">

--- a/resources/views/layouts/top-nav.blade.php
+++ b/resources/views/layouts/top-nav.blade.php
@@ -1,46 +1,31 @@
-<nav class="bg-primary" id="main-nav" aria-label="Main">
-    <div class="relative flex flex-wrap items-center justify-between px-4 py-2 max-w-6xl mx-auto">
-    <a class="inline-block py-1 mr-4 no-underline" href="{{ route('home') }}">
+<nav class="bg-primary sticky top-0 z-40" id="main-nav" aria-label="Main">
+    <div class="relative flex items-center justify-between gap-3 nav-break:gap-6 px-4 sm:px-6 py-2.5 max-w-6xl mx-auto">
+    <a class="shrink-0 py-1 no-underline [&_img]:h-12 nav-break:[&_img]:h-14" href="{{ route('home') }}" aria-label="Homepage">
         @include('includes.logo')
     </a>
 
     <input type="checkbox" id="nav-toggle" class="hidden peer" aria-hidden="true"/>
-    <label for="nav-toggle" class="nav-break:hidden px-3 py-1 rounded border border-white/10 cursor-pointer"
+    <label for="nav-toggle"
+           class="relative nav-break:hidden p-2.5 rounded-lg text-white/80 hover:text-white hover:bg-white/10 cursor-pointer peer-checked:[&_[data-icon=menu]]:hidden peer-checked:[&_[data-icon=close]]:block"
            aria-controls="navMenu" aria-expanded="false" aria-label="Toggle navigation">
-        <x-lucide-menu aria-hidden="true" class="w-6 h-6 text-white/70"/>
+        <span class="absolute top-1/2 left-1/2 size-[max(100%,3rem)] -translate-1/2 pointer-fine:hidden" aria-hidden="true"></span>
+        <x-lucide-menu data-icon="menu" aria-hidden="true" class="size-6"/>
+        <x-lucide-x data-icon="close" aria-hidden="true" class="hidden size-6"/>
     </label>
 
-    <div class="hidden peer-checked:block nav-break:flex nav-break:grow nav-break:items-center nav-break:justify-between nav-break:relative nav-break:bg-transparent nav-break:shadow-none nav-break:p-0 nav-break:w-auto absolute top-full left-0 right-0 z-50 bg-primary p-4 shadow-lg w-full"
+    <div class="hidden peer-checked:block nav-break:flex nav-break:grow nav-break:items-center nav-break:justify-between nav-break:relative nav-break:bg-transparent nav-break:border-0 nav-break:shadow-none nav-break:p-0 absolute top-full inset-x-0 z-50 bg-primary border-t border-white/10 p-3 shadow-lg"
          id="navMenu" role="navigation">
-        <ul class="flex flex-col nav-break:flex-row nav-break:items-center list-none pl-0 mb-0 mr-auto divide-y divide-white/10 nav-break:divide-y-0">
-
-            {{-- Events dropdown (desktop) --}}
-            <li class="hidden nav-break:block relative group">
-                <a href="{{ route('events.index') }}"
-                   aria-haspopup="true"
-                   class="flex items-center gap-1 py-2 px-2 text-sm font-medium no-underline transition-colors {{ Route::is('events.index') || Route::is('calendar.index') ? 'text-white font-semibold' : 'text-white/70 hover:text-white' }}">
-                    Events
-                    <x-lucide-chevron-down aria-hidden="true" class="w-3 h-3"/>
-                </a>
-                <div class="invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-150 absolute left-0 top-full pt-1 z-50">
-                    <ul class="bg-white rounded-lg shadow-lg border border-gray-200 py-1 min-w-[10rem] list-none pl-0 mb-0">
-                        <li>
-                            <a href="{{ route('events.index') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-primary no-underline transition-colors">
-                                Event List
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ route('calendar.index') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-primary no-underline transition-colors">
-                                Calendar View
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </li>
+        <ul role="list" class="flex flex-col gap-y-1 nav-break:flex-row nav-break:items-center nav-break:gap-x-1.5 list-none pl-0 mb-0 mr-auto">
 
             {{-- Mobile: events links flat --}}
             <x-nav-link route="events.index" class="nav-break:hidden">Events</x-nav-link>
             <x-nav-link route="calendar.index" class="nav-break:hidden">Calendar</x-nav-link>
+
+            {{-- Events dropdown (desktop) --}}
+            <x-nav-dropdown label="Events" :href="route('events.index')" :active="Route::is('events.index') || Route::is('calendar.index')">
+                <x-nav-dropdown-link route="events.index">Event List</x-nav-dropdown-link>
+                <x-nav-dropdown-link route="calendar.index">Calendar View</x-nav-dropdown-link>
+            </x-nav-dropdown>
 
             <x-nav-link route="orgs.index">Organizations</x-nav-link>
             <x-nav-link route="labs.index">Labs</x-nav-link>
@@ -48,35 +33,19 @@
             <x-nav-link route="about">About</x-nav-link>
 
             {{-- More dropdown (desktop) --}}
-            <li class="hidden nav-break:block relative group">
-                <button aria-haspopup="true" class="flex items-center gap-1 py-2 px-2 text-sm font-medium no-underline transition-colors text-white/70 hover:text-white">
-                    More
-                    <x-lucide-chevron-down aria-hidden="true" class="w-3 h-3"/>
-                </button>
-                <div class="invisible group-hover:visible opacity-0 group-hover:opacity-100 transition-all duration-150 absolute right-0 top-full pt-1 z-50">
-                    <ul class="bg-white rounded-lg shadow-lg border border-gray-200 py-1 min-w-[10rem] list-none pl-0 mb-0">
-                        <li>
-                            <a href="{{ route('contribute') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-primary no-underline transition-colors">
-                                Contribute
-                            </a>
-                        </li>
-                        <li>
-                            <a href="{{ route('contact') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-primary no-underline transition-colors">
-                                Contact
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-            </li>
+            <x-nav-dropdown label="More" align="right">
+                <x-nav-dropdown-link route="contribute">Contribute</x-nav-dropdown-link>
+                <x-nav-dropdown-link route="contact">Contact</x-nav-dropdown-link>
+            </x-nav-dropdown>
 
             {{-- Mobile: more links flat --}}
             <x-nav-link route="contribute" class="nav-break:hidden">Contribute</x-nav-link>
             <x-nav-link route="contact" class="nav-break:hidden">Contact</x-nav-link>
         </ul>
 
-        <div class="mt-2 pt-2 border-t border-white/20 nav-break:mt-0 nav-break:pt-0 nav-break:border-0 nav-break:ml-4">
+        <div class="mt-3 nav-break:mt-0 nav-break:ml-4">
             <a href="{{ route('join-slack') }}"
-               class="block nav-break:inline-block text-center text-white text-sm font-semibold no-underline bg-success hover:bg-green-700 rounded-full px-5 py-2 transition-colors">
+               class="block nav-break:inline-block text-center text-white text-base nav-break:text-sm font-semibold no-underline bg-success hover:bg-green-600 rounded-lg px-4 py-2.5 nav-break:py-2 transition-colors">
                 Join Slack
             </a>
         </div>

--- a/resources/views/orgs/index.blade.php
+++ b/resources/views/orgs/index.blade.php
@@ -1,15 +1,19 @@
-@extends('layouts.app')
+@extends('layouts.app', ['remove_space' => true])
 
 @section('title', 'Tech Organizations near Greenville, SC')
 @section('description', 'A list of tech meetups, code schools, tech conferences / hack-a-thons near Greenville, SC, including inactive organizations.')
 
 @section('content')
-    <div class="max-w-6xl mx-auto px-4 py-8">
+    {{-- Hero --}}
+    <x-hero id="orgs-hero" mode="interactive" canvas-id="orgs-hero-canvas" eyebrow="Community Directory">
+        Local Tech Organizations
 
-        <div class="mb-10">
-            <h1 class="text-3xl font-bold">Local Tech Organizations</h1>
-            <p class="text-gray-500 mt-1 text-sm">Groups, conferences, and programs in the Greenville, SC area</p>
-        </div>
+        <x-slot:subtitle>
+            Groups, conferences, and programs in the Greenville, SC area
+        </x-slot:subtitle>
+    </x-hero>
+
+    <div class="max-w-6xl mx-auto px-4 py-14 sm:py-16">
 
         @php
             $activeCategories = $activeOrgs->filter(fn($orgs) => !$orgs->first()->category->isInactive());
@@ -71,4 +75,14 @@
         @endforeach
 
     </div>
+@endsection
+
+@section('js')
+    <script type="module">
+    const canvas = document.getElementById('orgs-hero-canvas');
+    if (canvas) {
+        const { initHeroCanvas } = await window.loadLabsHero();
+        initHeroCanvas(canvas);
+    }
+    </script>
 @endsection

--- a/resources/views/slack/sign-up.blade.php
+++ b/resources/views/slack/sign-up.blade.php
@@ -10,9 +10,9 @@
                 <h1 class="text-3xl font-bold mb-6 text-gray-800">{{ __('Sign up for HackGreenville!') }}</h1>
 
                 <div class="mb-6">
-                    <a href="https://hackgreenville.slack.com" class="inline-block bg-success text-white px-6 py-3 rounded-full font-semibold hover:bg-green-600 transition-colors" rel="nofollow" target="_blank">
+                    <x-button href="https://hackgreenville.slack.com" rel="nofollow" target="_blank">
                         Already Signed Up? Log In to Slack
-                    </a>
+                    </x-button>
                 </div>
 
                 <p class="text-lg text-gray-700 mb-8">


### PR DESCRIPTION
TL;DR: This PR modernizes the site's look using the brand we already have (--color-primary, --color-success, Geist, the existing logo, and photography). Nearly all of it is Blade templates and Tailwind classes. It looks like a big change because the design touches many files — but most of the diff is repeated markup collapsing into ~8 small Blade components, with pages rewritten as short component calls. Also, the copy and text are the same as the current live site.

I tried to keep the ethos of this PR simple: make the design feel more polished and less broken than what we have today. At this stage, I wouldn’t overthink the design direction or spend time debating design decisions. The goal is simply to clean things up, fix inconsistencies, and tune the UI so it feels more cohesive and intentional.

---

Why now: the current design is already inconsistent in ways users can see:

1. Buttons exist in three shapes and sizes (rounded-full pills in the nav and Slack page, rounded-lg everywhere else, three padding scales, mixed font weights).
2. The nav's active state changes font-weight, which shifts the layout; its dropdowns are hover-only and invisible to keyboard users.
3. Hero overlays are brand-indigo on the homepage but generic gray-900 on HG Nights; eyebrow text was brand green on dark indigo (~2.4:1 contrast — below readable).
4. Headings flip between font-light/bold and centered/left page to page; event date formats differ between pages.
5. The body had no background color at all — dark-mode browsers rendered the site on a black canvas.

Overall, the design improves:

1. Element continuity — one button component (one size, three variants), one heading component, one hero component (plain / image / interactive backgrounds, focal-point control), one stat, one CTA banner, one event-row partial shared by home, events, and org pages. Future pages compose these instead of re-inventing them.
2. Readability and contrast — light-on-dark text bumped to accessible tints, active nav states use a soft background instead of a weight change, explicit white canvas, larger mobile type per breakpoint.
3. Accessibility — keyboard-accessible dropdowns, 48px touch targets, role="list", aria labels, and every animation respects prefers-reduced-motion.
4. Zero dependency cost — no new packages. Geist Mono ships from the already-installed geist package; tech logos are CC0 SVGs committed to public/img.

Suggested review path: read resources/views/components/ first (8 files, all short) — that's the whole design system. Everything after that is called sites. pint passes, php artisan test passes, yarn build is clean, and every page was verified at desktop and mobile widths.

## OLD

<img width="1308" height="2830" alt="CleanShot 2026-06-11 at 14 06 13@2x" src="https://github.com/user-attachments/assets/3d7e7308-d37b-4f64-a9d0-88f70e3f8f3d" />

## NEW

<img width="1286" height="2764" alt="image" src="https://github.com/user-attachments/assets/16d81058-d039-4fcc-81f4-cb6dad828c30" />