### PR TITLE
Allow yarn to update sharp beyond 0.32.0

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,7 +1,7 @@
 name: Run unit tests
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, synchronize, reopened ]
     branches:
       - master

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "laravel-vite-plugin": "^2.0.0",
         "pre-commit": "^1.2.2",
         "prettier": "^2.8.8",
-        "sharp": "0.32.0",
+        "sharp": "^0.32.0",
         "tailwindcss": "^4.0.0",
         "vite": "^7.0.7",
         "vite-plugin-image-optimizer": "^1.1.6"


### PR DESCRIPTION
We previously [froze the sharp package due to an old server Node 18 limitation](https://github.com/hackgvl/hackgreenville-com/pull/271) 

The new server shouldn't have this issue and there's a [security patch for sharp 0.35.0 that this PR will enable Dependabot to apply](https://github.com/hackgvl/hackgreenville-com/security/dependabot/128).